### PR TITLE
NATS: add default ack wait timeout

### DIFF
--- a/docs/content/docs/pub-sub-implementations.md
+++ b/docs/content/docs/pub-sub-implementations.md
@@ -303,8 +303,6 @@ NATS Streaming is a data streaming system powered by NATS, and written in the Go
 {{% load-snippet-partial file="content/src-link/message/infrastructure/nats/subscriber.go" first_line_contains="type StreamingSubscriberConfig struct" last_line_contains="type StreamingSubscriber struct" %}}
 {{% /render-md %}}
 
-Note: `AckWaitTimeout` will default to 30 seconds if not supplied. You may consider setting it to a lower value.
-
 #### Connecting
 
 By default NATS client will try to connect to `localhost:4222`. If you are using different hostname or port you should pass custom `stan.Option`: `stan.NatsURL("nats://your-nats-hostname:4222")` to `StreamingSubscriberConfig` and `StreamingPublisherConfig`.

--- a/docs/content/docs/pub-sub-implementations.md
+++ b/docs/content/docs/pub-sub-implementations.md
@@ -303,6 +303,8 @@ NATS Streaming is a data streaming system powered by NATS, and written in the Go
 {{% load-snippet-partial file="content/src-link/message/infrastructure/nats/subscriber.go" first_line_contains="type StreamingSubscriberConfig struct" last_line_contains="type StreamingSubscriber struct" %}}
 {{% /render-md %}}
 
+Note: `AckWaitTimeout` will default to 30 seconds if not supplied. You may consider setting it to a lower value.
+
 #### Connecting
 
 By default NATS client will try to connect to `localhost:4222`. If you are using different hostname or port you should pass custom `stan.Option`: `stan.NatsURL("nats://your-nats-hostname:4222")` to `StreamingSubscriberConfig` and `StreamingPublisherConfig`.

--- a/message/infrastructure/nats/subscriber.go
+++ b/message/infrastructure/nats/subscriber.go
@@ -83,15 +83,16 @@ func (c *StreamingSubscriberConfig) setDefaults() {
 	if c.CloseTimeout <= 0 {
 		c.CloseTimeout = time.Second * 30
 	}
+	if c.AckWaitTimeout <= 0 {
+		c.AckWaitTimeout = time.Second * 30
+	}
 
 	c.StanSubscriptionOptions = append(
 		c.StanSubscriptionOptions,
 		stan.SetManualAckMode(), // manual AckMode is required to support acking/nacking by client
+		stan.AckWait(c.AckWaitTimeout),
 	)
 
-	if c.AckWaitTimeout != 0 {
-		c.StanSubscriptionOptions = append(c.StanSubscriptionOptions, stan.AckWait(c.AckWaitTimeout))
-	}
 	if c.DurableName != "" {
 		c.StanSubscriptionOptions = append(c.StanSubscriptionOptions, stan.DurableName(c.DurableName))
 	}


### PR DESCRIPTION
The lack of default value causes ACK timeout immediately, if not supplied.