### PR TITLE
Set Kafka message key

### DIFF
--- a/message/infrastructure/kafka/marshaler.go
+++ b/message/infrastructure/kafka/marshaler.go
@@ -45,7 +45,7 @@ func (DefaultMarshaler) Marshal(topic string, msg *message.Message) (*sarama.Pro
 		Topic:   topic,
 		Value:   sarama.ByteEncoder(msg.Payload),
 		Headers: headers,
-		Key:     sarama.StringEncoder(msg.UUID),
+		Key:     sarama.ByteEncoder(msg.UUID),
 	}, nil
 }
 

--- a/message/infrastructure/kafka/marshaler.go
+++ b/message/infrastructure/kafka/marshaler.go
@@ -45,6 +45,7 @@ func (DefaultMarshaler) Marshal(topic string, msg *message.Message) (*sarama.Pro
 		Topic:   topic,
 		Value:   sarama.ByteEncoder(msg.Payload),
 		Headers: headers,
+		Key:     sarama.StringEncoder(msg.UUID),
 	}, nil
 }
 


### PR DESCRIPTION
Kafka message key was not set previously. Because of that, I was not able to publish messages to Compact Kafka topics.