### PR TITLE
Make configuring topology more flexible

### DIFF
--- a/message/infrastructure/amqp/config.go
+++ b/message/infrastructure/amqp/config.go
@@ -57,6 +57,7 @@ func NewDurablePubSubConfig(amqpURI string, generateQueueName QueueNameGenerator
 				PrefetchCount: 1,
 			},
 		},
+		TopologyBuilder:&DefaultTopologyBuilder{},
 	}
 }
 
@@ -102,6 +103,7 @@ func NewNonDurablePubSubConfig(amqpURI string, generateQueueName QueueNameGenera
 				PrefetchCount: 1,
 			},
 		},
+		TopologyBuilder:&DefaultTopologyBuilder{},
 	}
 }
 
@@ -147,6 +149,7 @@ func NewDurableQueueConfig(amqpURI string) Config {
 				PrefetchCount: 1,
 			},
 		},
+		TopologyBuilder:&DefaultTopologyBuilder{},
 	}
 }
 
@@ -190,6 +193,7 @@ func NewNonDurableQueueConfig(amqpURI string) Config {
 				PrefetchCount: 1,
 			},
 		},
+		TopologyBuilder:&DefaultTopologyBuilder{},
 	}
 }
 
@@ -204,6 +208,8 @@ type Config struct {
 
 	Publish PublishConfig
 	Consume ConsumeConfig
+
+	TopologyBuilder TopologyBuilder
 }
 
 func (c Config) validate() error {

--- a/message/infrastructure/amqp/config.go
+++ b/message/infrastructure/amqp/config.go
@@ -248,18 +248,6 @@ func (c Config) ValidateSubscriber() error {
 	return err
 }
 
-func (c Config) exchangeDeclare(channel *amqp.Channel, exchangeName string) error {
-	return channel.ExchangeDeclare(
-		exchangeName,
-		c.Exchange.Type,
-		c.Exchange.Durable,
-		c.Exchange.AutoDeleted,
-		c.Exchange.Internal,
-		c.Exchange.NoWait,
-		c.Exchange.Arguments,
-	)
-}
-
 type ConnectionConfig struct {
 	AmqpURI string
 

--- a/message/infrastructure/amqp/config.go
+++ b/message/infrastructure/amqp/config.go
@@ -24,7 +24,7 @@ import (
 // with durable added for exchange, queue and amqp.Persistent DeliveryMode.
 // Thanks to this, we don't lose messages on broker restart.
 func NewDurablePubSubConfig(amqpURI string, generateQueueName QueueNameGenerator) Config {
-	return Config{
+	config := Config{
 		Connection: ConnectionConfig{
 			AmqpURI: amqpURI,
 		},
@@ -58,6 +58,12 @@ func NewDurablePubSubConfig(amqpURI string, generateQueueName QueueNameGenerator
 			},
 		},
 	}
+
+	config.TopologyBuilder = DefaultTopologyBuilder{
+		config:config,
+	}
+
+	return config
 }
 
 // NewNonDurablePubSubConfig creates config for non durable PubSub.

--- a/message/infrastructure/amqp/config.go
+++ b/message/infrastructure/amqp/config.go
@@ -248,6 +248,18 @@ func (c Config) ValidateSubscriber() error {
 	return err
 }
 
+func (c Config) exchangeDeclare(channel *amqp.Channel, exchangeName string) error {
+	return channel.ExchangeDeclare(
+		exchangeName,
+		c.Exchange.Type,
+		c.Exchange.Durable,
+		c.Exchange.AutoDeleted,
+		c.Exchange.Internal,
+		c.Exchange.NoWait,
+		c.Exchange.Arguments,
+	)
+}
+
 type ConnectionConfig struct {
 	AmqpURI string
 

--- a/message/infrastructure/amqp/config.go
+++ b/message/infrastructure/amqp/config.go
@@ -24,7 +24,7 @@ import (
 // with durable added for exchange, queue and amqp.Persistent DeliveryMode.
 // Thanks to this, we don't lose messages on broker restart.
 func NewDurablePubSubConfig(amqpURI string, generateQueueName QueueNameGenerator) Config {
-	config := Config{
+	return Config{
 		Connection: ConnectionConfig{
 			AmqpURI: amqpURI,
 		},
@@ -58,12 +58,6 @@ func NewDurablePubSubConfig(amqpURI string, generateQueueName QueueNameGenerator
 			},
 		},
 	}
-
-	config.TopologyBuilder = DefaultTopologyBuilder{
-		config:config,
-	}
-
-	return config
 }
 
 // NewNonDurablePubSubConfig creates config for non durable PubSub.

--- a/message/infrastructure/amqp/connection.go
+++ b/message/infrastructure/amqp/connection.go
@@ -47,18 +47,6 @@ func newConnection(
 	return pubSub, nil
 }
 
-func (c *connectionWrapper) exchangeDeclare(channel *amqp.Channel, exchangeName string) error {
-	return channel.ExchangeDeclare(
-		exchangeName,
-		c.config.Exchange.Type,
-		c.config.Exchange.Durable,
-		c.config.Exchange.AutoDeleted,
-		c.config.Exchange.Internal,
-		c.config.Exchange.NoWait,
-		c.config.Exchange.Arguments,
-	)
-}
-
 func (c *connectionWrapper) Close() error {
 	if c.closed {
 		return nil

--- a/message/infrastructure/amqp/publisher.go
+++ b/message/infrastructure/amqp/publisher.go
@@ -149,7 +149,7 @@ func (p *Publisher) preparePublishBindings(topic string, channel *amqp.Channel) 
 	defer p.publishBindingsLock.Unlock()
 
 	if p.config.Exchange.GenerateName(topic) != "" {
-		if err := p.config.exchangeDeclare(channel, p.config.Exchange.GenerateName(topic)); err != nil {
+		if err := p.config.TopologyBuilder.ExchangeDeclare(channel, p.config.Exchange.GenerateName(topic), p.config); err != nil {
 			return err
 		}
 	}

--- a/message/infrastructure/amqp/publisher.go
+++ b/message/infrastructure/amqp/publisher.go
@@ -149,7 +149,7 @@ func (p *Publisher) preparePublishBindings(topic string, channel *amqp.Channel) 
 	defer p.publishBindingsLock.Unlock()
 
 	if p.config.Exchange.GenerateName(topic) != "" {
-		if err := p.exchangeDeclare(channel, p.config.Exchange.GenerateName(topic)); err != nil {
+		if err := p.config.exchangeDeclare(channel, p.config.Exchange.GenerateName(topic)); err != nil {
 			return err
 		}
 	}

--- a/message/infrastructure/amqp/subscriber.go
+++ b/message/infrastructure/amqp/subscriber.go
@@ -124,7 +124,7 @@ func (s *Subscriber) prepareConsume(queueName string, exchangeName string, logFi
 		}
 	}()
 
-	if err = s.config.TopologyBuilder.BuildTopology(channel, queueName, exchangeName, s.exchangeDeclare, s.config, s.logger); err != nil {
+	if err = s.config.TopologyBuilder.BuildTopology(channel, queueName, exchangeName, s.config, s.logger); err != nil {
 		return err
 	}
 

--- a/message/infrastructure/amqp/subscriber.go
+++ b/message/infrastructure/amqp/subscriber.go
@@ -15,8 +15,8 @@ import (
 type Subscriber struct {
 	*connectionWrapper
 
-	config Config
-	topologyBuilder topologyBuilder
+	config          Config
+	topologyBuilder TopologyBuilder
 }
 
 func NewSubscriber(config Config, logger watermill.LoggerAdapter) (*Subscriber, error) {
@@ -29,8 +29,8 @@ func NewSubscriber(config Config, logger watermill.LoggerAdapter) (*Subscriber, 
 		return nil, err
 	}
 
-	return &Subscriber{conn, config, &defaultTopologyBuilder{
-		config, logger,
+	return &Subscriber{conn, config, &DefaultTopologyBuilder{
+		config: config, logger: logger,
 	}}, nil
 }
 
@@ -94,7 +94,7 @@ func (s *Subscriber) Subscribe(ctx context.Context, topic string) (<-chan *messa
 	return out, nil
 }
 
-func (s *Subscriber) SetTopologyBuilder(builder topologyBuilder) {
+func (s *Subscriber) SetTopologyBuilder(builder TopologyBuilder) {
 	s.topologyBuilder = builder
 }
 
@@ -131,7 +131,7 @@ func (s *Subscriber) prepareConsume(queueName string, exchangeName string, logFi
 		}
 	}()
 
-	if err = s.topologyBuilder.buildTopology(channel, queueName, logFields, exchangeName, s.exchangeDeclare); err != nil {
+	if err = s.topologyBuilder.buildTopology(channel, queueName, exchangeName, s.exchangeDeclare); err != nil {
 		return err
 	}
 

--- a/message/infrastructure/amqp/subscriber.go
+++ b/message/infrastructure/amqp/subscriber.go
@@ -124,7 +124,7 @@ func (s *Subscriber) prepareConsume(queueName string, exchangeName string, logFi
 		}
 	}()
 
-	if err = s.config.TopologyBuilder.BuildTopology(channel, queueName, exchangeName, s.exchangeDeclare, s.config, s.logger, logFields); err != nil {
+	if err = s.config.TopologyBuilder.BuildTopology(channel, queueName, exchangeName, s.exchangeDeclare, s.config, s.logger); err != nil {
 		return err
 	}
 

--- a/message/infrastructure/amqp/subscriber.go
+++ b/message/infrastructure/amqp/subscriber.go
@@ -131,7 +131,7 @@ func (s *Subscriber) prepareConsume(queueName string, exchangeName string, logFi
 		}
 	}()
 
-	if err = s.topologyBuilder.buildTopology(channel, queueName, exchangeName, s.exchangeDeclare); err != nil {
+	if err = s.topologyBuilder.BuildTopology(channel, queueName, exchangeName, s.exchangeDeclare); err != nil {
 		return err
 	}
 

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TopologyBuilder interface {
-	buildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error
+	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error
 }
 
 type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
@@ -18,7 +18,7 @@ type DefaultTopologyBuilder struct {
 	logFields watermill.LogFields
 }
 
-func (builder *DefaultTopologyBuilder) buildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error  {
+func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error  {
 	if _, err := channel.QueueDeclare(
 		queueName,
 		builder.config.Queue.Durable,

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -7,15 +7,13 @@ import (
 )
 
 type TopologyBuilder interface {
-	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclare ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error
+	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, config Config, logger watermill.LoggerAdapter) error
 }
-
-type ExchangeDeclare func(channel *amqp.Channel, exchangeName string) error
 
 type DefaultTopologyBuilder struct {
 }
 
-func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclare ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error  {
+func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, config Config, logger watermill.LoggerAdapter) error  {
 	if _, err := channel.QueueDeclare(
 		queueName,
 		config.Queue.Durable,
@@ -33,7 +31,7 @@ func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queu
 		logger.Debug("No exchange to declare", nil)
 		return nil
 	}
-	if err := exchangeDeclare(channel, exchangeName); err != nil {
+	if err := config.exchangeDeclare(channel, exchangeName); err != nil {
 		return errors.Wrap(err, "cannot declare exchange")
 	}
 

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -7,15 +7,15 @@ import (
 )
 
 type TopologyBuilder interface {
-	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter) error
+	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error
 }
 
-type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
+type ExchangeDeclare func(channel *amqp.Channel, exchangeName string) error
 
 type DefaultTopologyBuilder struct {
 }
 
-func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter) error  {
+func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error  {
 	if _, err := channel.QueueDeclare(
 		queueName,
 		config.Queue.Durable,

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TopologyBuilder interface {
-	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error
+	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclare ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error
 }
 
 type ExchangeDeclare func(channel *amqp.Channel, exchangeName string) error
@@ -15,7 +15,7 @@ type ExchangeDeclare func(channel *amqp.Channel, exchangeName string) error
 type DefaultTopologyBuilder struct {
 }
 
-func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error  {
+func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclare ExchangeDeclare, config Config, logger watermill.LoggerAdapter) error  {
 	if _, err := channel.QueueDeclare(
 		queueName,
 		config.Queue.Durable,
@@ -33,7 +33,7 @@ func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queu
 		logger.Debug("No exchange to declare", nil)
 		return nil
 	}
-	if err := exchangeDeclarer(channel, exchangeName); err != nil {
+	if err := exchangeDeclare(channel, exchangeName); err != nil {
 		return errors.Wrap(err, "cannot declare exchange")
 	}
 

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -7,47 +7,44 @@ import (
 )
 
 type TopologyBuilder interface {
-	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error
+	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter, logFields watermill.LogFields) error
 }
 
 type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
 
 type DefaultTopologyBuilder struct {
-	config Config
-	logger watermill.LoggerAdapter
-	logFields watermill.LogFields
 }
 
-func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error  {
+func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter, logFields watermill.LogFields) error  {
 	if _, err := channel.QueueDeclare(
 		queueName,
-		builder.config.Queue.Durable,
-		builder.config.Queue.AutoDelete,
-		builder.config.Queue.Exclusive,
-		builder.config.Queue.NoWait,
-		builder.config.Queue.Arguments,
+		config.Queue.Durable,
+		config.Queue.AutoDelete,
+		config.Queue.Exclusive,
+		config.Queue.NoWait,
+		config.Queue.Arguments,
 	); err != nil {
 		return errors.Wrap(err, "cannot declare queue")
 	}
 
-	builder.logger.Debug("Queue declared", builder.logFields)
+	logger.Debug("Queue declared", logFields)
 
 	if exchangeName == "" {
-		builder.logger.Debug("No exchange to declare", builder.logFields)
+		logger.Debug("No exchange to declare", logFields)
 		return nil
 	}
 	if err := exchangeDeclarer(channel, exchangeName); err != nil {
 		return errors.Wrap(err, "cannot declare exchange")
 	}
 
-	builder.logger.Debug("Exchange declared", builder.logFields)
+	logger.Debug("Exchange declared", logFields)
 
 	if err := channel.QueueBind(
 		queueName,
-		builder.config.QueueBind.GenerateRoutingKey(queueName),
+		config.QueueBind.GenerateRoutingKey(queueName),
 		exchangeName,
-		builder.config.QueueBind.NoWait,
-		builder.config.QueueBind.Arguments,
+		config.QueueBind.NoWait,
+		config.QueueBind.Arguments,
 	); err != nil {
 		return errors.Wrap(err, "cannot bind queue")
 	}

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -1,0 +1,54 @@
+package amqp
+
+import (
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/pkg/errors"
+	"github.com/streadway/amqp"
+)
+
+type topologyBuilder interface {
+	buildTopology(channel *amqp.Channel, queueName string, logFields watermill.LogFields, exchangeName string, exchangeDeclarer exchangeDeclarer) error
+}
+
+type exchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
+
+type defaultTopologyBuilder struct {
+	config Config
+	logger watermill.LoggerAdapter
+}
+
+func (builder *defaultTopologyBuilder) buildTopology(channel *amqp.Channel, queueName string, logFields watermill.LogFields, exchangeName string, exchangeDeclarer exchangeDeclarer) error  {
+	if _, err := channel.QueueDeclare(
+		queueName,
+		builder.config.Queue.Durable,
+		builder.config.Queue.AutoDelete,
+		builder.config.Queue.Exclusive,
+		builder.config.Queue.NoWait,
+		builder.config.Queue.Arguments,
+	); err != nil {
+		return errors.Wrap(err, "cannot declare queue")
+	}
+
+	builder.logger.Debug("Queue declared", logFields)
+
+	if exchangeName == "" {
+		builder.logger.Debug("No exchange to declare", logFields)
+		return nil
+	}
+	if err := exchangeDeclarer(channel, exchangeName); err != nil {
+		return errors.Wrap(err, "cannot declare exchange")
+	}
+
+	builder.logger.Debug("Exchange declared", logFields)
+
+	if err := channel.QueueBind(
+		queueName,
+		builder.config.QueueBind.GenerateRoutingKey(queueName),
+		exchangeName,
+		builder.config.QueueBind.NoWait,
+		builder.config.QueueBind.Arguments,
+	); err != nil {
+		return errors.Wrap(err, "cannot bind queue")
+	}
+	return nil
+}

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -10,7 +10,7 @@ type TopologyBuilder interface {
 	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error
 }
 
-type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string, config Config, logger watermill.LoggerAdapter) error
+type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
 
 type DefaultTopologyBuilder struct {
 	config Config

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TopologyBuilder interface {
-	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter, logFields watermill.LogFields) error
+	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter) error
 }
 
 type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
@@ -15,7 +15,7 @@ type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
 type DefaultTopologyBuilder struct {
 }
 
-func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter, logFields watermill.LogFields) error  {
+func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer, config Config, logger watermill.LoggerAdapter) error  {
 	if _, err := channel.QueueDeclare(
 		queueName,
 		config.Queue.Durable,
@@ -27,17 +27,17 @@ func (builder *DefaultTopologyBuilder) BuildTopology(channel *amqp.Channel, queu
 		return errors.Wrap(err, "cannot declare queue")
 	}
 
-	logger.Debug("Queue declared", logFields)
+	logger.Debug("Queue declared", nil)
 
 	if exchangeName == "" {
-		logger.Debug("No exchange to declare", logFields)
+		logger.Debug("No exchange to declare", nil)
 		return nil
 	}
 	if err := exchangeDeclarer(channel, exchangeName); err != nil {
 		return errors.Wrap(err, "cannot declare exchange")
 	}
 
-	logger.Debug("Exchange declared", logFields)
+	logger.Debug("Exchange declared", nil)
 
 	if err := channel.QueueBind(
 		queueName,

--- a/message/infrastructure/amqp/topology_builder.go
+++ b/message/infrastructure/amqp/topology_builder.go
@@ -10,7 +10,7 @@ type TopologyBuilder interface {
 	BuildTopology(channel *amqp.Channel, queueName string, exchangeName string, exchangeDeclarer ExchangeDeclarer) error
 }
 
-type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string) error
+type ExchangeDeclarer func(channel *amqp.Channel, exchangeName string, config Config, logger watermill.LoggerAdapter) error
 
 type DefaultTopologyBuilder struct {
 	config Config


### PR DESCRIPTION
Ou our RabbitMQ, we have topologies with 2 exchanges and we use routing keys to route the messages between exchanges/queues.

The problem we are facing is that we cannot configure 2 topologies currently. The fix adds a builder which can be easily replaced with a custom one.

There are no breaking changes.