### PR TITLE
Fix gochannel-related races

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -110,9 +110,10 @@ type Router struct {
 	handlersWg        *sync.WaitGroup
 	runningHandlersWg *sync.WaitGroup
 
-	closeCh  chan struct{}
-	closedCh chan struct{}
-	closed   bool
+	closeCh    chan struct{}
+	closedCh   chan struct{}
+	closed     bool
+	closedLock sync.Mutex
 
 	logger watermill.LoggerAdapter
 
@@ -324,7 +325,7 @@ func (r *Router) Run(ctx context.Context) (err error) {
 // because for example all subscriptions are closed.
 func (r *Router) closeWhenAllHandlersStopped() {
 	r.handlersWg.Wait()
-	if r.closed {
+	if r.isClosed() {
 		// already closed
 		return
 	}
@@ -347,6 +348,9 @@ func (r *Router) Running() chan struct{} {
 }
 
 func (r *Router) Close() error {
+	r.closedLock.Lock()
+	defer r.closedLock.Unlock()
+
 	if r.closed {
 		return nil
 	}
@@ -364,6 +368,13 @@ func (r *Router) Close() error {
 	}
 
 	return nil
+}
+
+func (r *Router) isClosed() bool {
+	r.closedLock.Lock()
+	defer r.closedLock.Unlock()
+
+	return r.closed
 }
 
 type handler struct {

--- a/message/router_test.go
+++ b/message/router_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ThreeDotsLabs/watermill/pubsub/tests"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +15,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/subscriber"
 	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+	"github.com/ThreeDotsLabs/watermill/pubsub/tests"
 )
 
 func TestRouter_functional(t *testing.T) {

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -80,11 +80,9 @@ func NewGoChannel(config Config, logger watermill.LoggerAdapter) *GoChannel {
 //
 // Messages may be persisted or not, depending of persistent attribute.
 func (g *GoChannel) Publish(topic string, messages ...*message.Message) error {
-	g.closedLock.Lock()
-	if g.closed {
+	if g.isClosed() {
 		return errors.New("Pub/Sub closed")
 	}
-	g.closedLock.Unlock()
 
 	for i, msg := range messages {
 		messages[i] = msg.Copy()
@@ -265,6 +263,13 @@ func (g *GoChannel) topicSubscribers(topic string) []*subscriber {
 	}
 
 	return subscribers
+}
+
+func (g *GoChannel) isClosed() bool {
+	g.closedLock.Lock()
+	defer g.closedLock.Unlock()
+
+	return g.closed
 }
 
 func (g *GoChannel) Close() error {

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -188,9 +188,6 @@ func (g *GoChannel) Subscribe(ctx context.Context, topic string) (<-chan *messag
 
 		s.Close()
 
-		g.subscribersLock.Lock()
-		defer g.subscribersLock.Unlock()
-
 		subLock, _ := g.subscribersByTopicLock.Load(topic)
 		subLock.(*sync.Mutex).Lock()
 		defer subLock.(*sync.Mutex).Unlock()
@@ -280,6 +277,9 @@ func (g *GoChannel) Close() error {
 	close(g.closing)
 
 	g.logger.Debug("Closing Pub/Sub, waiting for subscribers", nil)
+
+	g.subscribersLock.Lock()
+	defer g.subscribersLock.Unlock()
 
 	g.subscribersWg.Wait()
 

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -279,7 +279,6 @@ func (g *GoChannel) Close() error {
 	close(g.closing)
 
 	g.logger.Debug("Closing Pub/Sub, waiting for subscribers", nil)
-
 	g.subscribersWg.Wait()
 
 	g.logger.Info("Pub/Sub closed", nil)


### PR DESCRIPTION
This PR fixes data races reported by #111. They are related with concurrent closing of gochannel PubSub and Router.