### PR TITLE
Print stacktrace on panic recover.

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -3,6 +3,7 @@ package message
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -498,7 +499,11 @@ func (h *handler) handleMessage(msg *Message, handler HandlerFunc) {
 
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			h.logger.Error("Panic recovered in handler", errors.Errorf("%s", recovered), nil)
+			h.logger.Error(
+				"Panic recovered in handler. Stack: " + string(debug.Stack()),
+				errors.Errorf("%s", recovered),
+				nil,
+			)
 			msg.Nack()
 			return
 		}


### PR DESCRIPTION
Hey there! We had some problems with finding panic reason in our code. Added stack trace to error log.