### PR TITLE
Bump examples to watermill-kafka v2.0.0

### DIFF
--- a/_examples/basic/1-your-first-app/go.mod
+++ b/_examples/basic/1-your-first-app/go.mod
@@ -2,5 +2,5 @@ module main.go
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 )

--- a/_examples/basic/1-your-first-app/go.sum
+++ b/_examples/basic/1-your-first-app/go.sum
@@ -7,8 +7,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t9x786FOZmoAh4=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/_examples/basic/1-your-first-app/main.go
+++ b/_examples/basic/1-your-first-app/main.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
@@ -94,9 +94,10 @@ func main() {
 // createPublisher is a helper function that creates a Publisher, in this case - the Kafka Publisher.
 func createPublisher() message.Publisher {
 	kafkaPublisher, err := kafka.NewPublisher(
-		brokers,
-		marshaler,
-		nil,
+		kafka.PublisherConfig{
+			Brokers:   brokers,
+			Marshaler: marshaler,
+		},
 		logger,
 	)
 	if err != nil {
@@ -108,10 +109,14 @@ func createPublisher() message.Publisher {
 
 // createSubscriber is a helper function similar to the previous one, but in this case it creates a Subscriber.
 func createSubscriber(consumerGroup string) message.Subscriber {
-	kafkaSubscriber, err := kafka.NewSubscriber(kafka.SubscriberConfig{
-		Brokers:       brokers,
-		ConsumerGroup: consumerGroup, // every handler will use a separate consumer group
-	}, nil, marshaler, logger)
+	kafkaSubscriber, err := kafka.NewSubscriber(
+		kafka.SubscriberConfig{
+			Brokers:       brokers,
+			Unmarshaler:   marshaler,
+			ConsumerGroup: consumerGroup, // every handler will use a separate consumer group
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/basic/2-realtime-feed/consumer/go.mod
+++ b/_examples/basic/2-realtime-feed/consumer/go.mod
@@ -2,6 +2,6 @@ module main.go
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 	github.com/pkg/errors v0.8.1
 )

--- a/_examples/basic/2-realtime-feed/consumer/go.sum
+++ b/_examples/basic/2-realtime-feed/consumer/go.sum
@@ -7,8 +7,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t9x786FOZmoAh4=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=

--- a/_examples/basic/2-realtime-feed/consumer/main.go
+++ b/_examples/basic/2-realtime-feed/consumer/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
@@ -25,7 +25,13 @@ func main() {
 	logger := watermill.NewStdLogger(false, false)
 	logger.Info("Starting the consumer", nil)
 
-	pub, err := kafka.NewPublisher(brokers, marshaler, nil, logger)
+	pub, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:   brokers,
+			Marshaler: marshaler,
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -101,10 +107,9 @@ func createSubscriber(consumerGroup string, logger watermill.LoggerAdapter) mess
 	sub, err := kafka.NewSubscriber(
 		kafka.SubscriberConfig{
 			Brokers:       brokers,
+			Unmarshaler:   marshaler,
 			ConsumerGroup: consumerGroup,
 		},
-		nil,
-		marshaler,
 		logger,
 	)
 	if err != nil {

--- a/_examples/basic/2-realtime-feed/producer/go.mod
+++ b/_examples/basic/2-realtime-feed/producer/go.mod
@@ -2,6 +2,6 @@ module main.go
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 )

--- a/_examples/basic/2-realtime-feed/producer/go.sum
+++ b/_examples/basic/2-realtime-feed/producer/go.sum
@@ -7,8 +7,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t9x786FOZmoAh4=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/_examples/basic/2-realtime-feed/producer/main.go
+++ b/_examples/basic/2-realtime-feed/producer/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brianvoe/gofakeit"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 )
@@ -30,7 +30,13 @@ func main() {
 
 	rand.Seed(time.Now().Unix())
 
-	publisher, err := kafka.NewPublisher(brokers, kafka.DefaultMarshaler{}, nil, logger)
+	publisher, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:   brokers,
+			Marshaler: kafka.DefaultMarshaler{},
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/http-to-kafka/go.mod
+++ b/_examples/http-to-kafka/go.mod
@@ -3,6 +3,6 @@ module main.go
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
 	github.com/ThreeDotsLabs/watermill-http v1.0.1
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 	github.com/pkg/errors v0.8.1
 )

--- a/_examples/http-to-kafka/go.sum
+++ b/_examples/http-to-kafka/go.sum
@@ -9,8 +9,8 @@ github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
 github.com/ThreeDotsLabs/watermill-http v1.0.1 h1:9g/toufWmYAZvBOnHcugXiV4yG5X33/1B0oZLwztS7M=
 github.com/ThreeDotsLabs/watermill-http v1.0.1/go.mod h1:zb7mWf582wx5x/uy0N9PGfiZCG0f63Tk/D4sNtidTSk=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=

--- a/_examples/http-to-kafka/main.go
+++ b/_examples/http-to-kafka/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-http/pkg/http"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
@@ -31,7 +31,13 @@ func main() {
 	flag.Parse()
 	logger := watermill.NewStdLogger(true, true)
 
-	kafkaPublisher, err := kafka.NewPublisher([]string{*kafkaAddr}, kafka.DefaultMarshaler{}, nil, logger)
+	kafkaPublisher, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:   []string{*kafkaAddr},
+			Marshaler: kafka.DefaultMarshaler{},
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/kafka-to-http/producer/go.mod
+++ b/_examples/kafka-to-http/producer/go.mod
@@ -2,5 +2,5 @@ module main.go
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 )

--- a/_examples/kafka-to-http/producer/go.sum
+++ b/_examples/kafka-to-http/producer/go.sum
@@ -7,8 +7,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t9x786FOZmoAh4=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/_examples/kafka-to-http/producer/main.go
+++ b/_examples/kafka-to-http/producer/main.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 )
 
@@ -24,7 +24,13 @@ const (
 )
 
 func main() {
-	pub, err := kafka.NewPublisher(brokers, kafka.DefaultMarshaler{}, nil, logger)
+	pub, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:   brokers,
+			Marshaler: kafka.DefaultMarshaler{},
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/kafka-to-http/router/go.mod
+++ b/_examples/kafka-to-http/router/go.mod
@@ -3,5 +3,5 @@ module main.go
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
 	github.com/ThreeDotsLabs/watermill-http v1.0.1
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 )

--- a/_examples/kafka-to-http/router/go.sum
+++ b/_examples/kafka-to-http/router/go.sum
@@ -9,8 +9,8 @@ github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
 github.com/ThreeDotsLabs/watermill-http v1.0.1 h1:9g/toufWmYAZvBOnHcugXiV4yG5X33/1B0oZLwztS7M=
 github.com/ThreeDotsLabs/watermill-http v1.0.1/go.mod h1:zb7mWf582wx5x/uy0N9PGfiZCG0f63Tk/D4sNtidTSk=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/_examples/kafka-to-http/router/main.go
+++ b/_examples/kafka-to-http/router/main.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill"
 	watermill_http "github.com/ThreeDotsLabs/watermill-http/pkg/http"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/plugin"
 )
@@ -39,9 +39,13 @@ func main() {
 		panic(err)
 	}
 
-	subscriber, err := kafka.NewSubscriber(kafka.SubscriberConfig{
-		Brokers: []string{"kafka:9092"},
-	}, nil, kafka.DefaultMarshaler{}, logger)
+	subscriber, err := kafka.NewSubscriber(
+		kafka.SubscriberConfig{
+			Brokers:     []string{"kafka:9092"},
+			Unmarshaler: kafka.DefaultMarshaler{},
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/_examples/sql/transactional-events/go.mod
+++ b/_examples/sql/transactional-events/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1 // indirect
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 	github.com/ThreeDotsLabs/watermill-sql v0.1.1
 	github.com/go-sql-driver/mysql v1.4.1
 )

--- a/_examples/sql/transactional-events/go.sum
+++ b/_examples/sql/transactional-events/go.sum
@@ -3,11 +3,12 @@ github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Shopify/sarama v1.23.1 h1:XxJBCZEoWJtoWjf/xRbmGUpAmTZGnuuF0ON0EvxxBrs=
 github.com/Shopify/sarama v1.23.1/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
+github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t9x786FOZmoAh4=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/ThreeDotsLabs/watermill-sql v0.1.1 h1:OV6/At1Xr1UZh4AgRQ7TIjHKoS5UdENtsNcJwAdmOfM=
 github.com/ThreeDotsLabs/watermill-sql v0.1.1/go.mod h1:8+1e0mPYBfFZxVloUHgxDPoHXqtNKtVYHgGd3wZdhcs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -26,6 +27,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/frankban/quicktest v1.4.0 h1:rCSCih1FnSWJEel/eub9wclBSqpF2F/PuvxUWGWnbO8=
 github.com/frankban/quicktest v1.4.0/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -40,6 +42,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -58,8 +61,10 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -74,6 +79,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -91,6 +97,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
@@ -113,6 +120,7 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/appengine v1.6.0 h1:Tfd7cKwKbFRsI8RMAD3oqqw7JPFRrvFlOsfbgVkjOOw=
 google.golang.org/appengine v1.6.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -120,6 +128,7 @@ gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hr
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eRhxkJMWSIz9Q=
+gopkg.in/jcmturner/goidentity.v3 v3.0.0 h1:1duIyWiTaYvVx3YX2CYtpJbUFd7/UuPYCfgXtQ3VTbI=
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/gokrb5.v7 v7.3.0 h1:0709Jtq/6QXEuWRfAm260XqlpcwL1vxtO1tUE2qK8Z4=

--- a/_examples/sql/transactional-events/main.go
+++ b/_examples/sql/transactional-events/main.go
@@ -10,7 +10,7 @@ import (
 	driver "github.com/go-sql-driver/mysql"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill-sql/pkg/sql"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
@@ -105,9 +105,10 @@ func createSubscriber(db *stdSQL.DB) message.Subscriber {
 
 func createPublisher() message.Publisher {
 	pub, err := kafka.NewPublisher(
-		[]string{"kafka:9092"},
-		kafka.DefaultMarshaler{},
-		nil,
+		kafka.PublisherConfig{
+			Brokers:   []string{"kafka:9092"},
+			Marshaler: kafka.DefaultMarshaler{},
+		},
 		logger,
 	)
 	if err != nil {

--- a/docs/content/docs/getting-started/kafka/go.mod
+++ b/docs/content/docs/getting-started/kafka/go.mod
@@ -3,5 +3,5 @@ module main.go
 require (
 	github.com/Shopify/sarama v1.23.1
 	github.com/ThreeDotsLabs/watermill v1.0.0-rc.2
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 )

--- a/docs/content/docs/getting-started/kafka/go.sum
+++ b/docs/content/docs/getting-started/kafka/go.sum
@@ -7,8 +7,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2 h1:DCKR8kSLHUyZny6LiKtO7h+IZPMo0t9x786FOZmoAh4=
 github.com/ThreeDotsLabs/watermill v1.0.0-rc.2/go.mod h1:gjVFKc8aN+vmEHw3pA0kh4mmuwHe02nyfghb6IWWiKE=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/docs/content/docs/getting-started/kafka/main.go
+++ b/docs/content/docs/getting-started/kafka/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Shopify/sarama"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 )
 
@@ -20,11 +20,11 @@ func main() {
 
 	subscriber, err := kafka.NewSubscriber(
 		kafka.SubscriberConfig{
-			Brokers:       []string{"kafka:9092"},
-			ConsumerGroup: "test_consumer_group",
+			Brokers:               []string{"kafka:9092"},
+			Unmarshaler:           kafka.DefaultMarshaler{},
+			OverwriteSaramaConfig: saramaSubscriberConfig,
+			ConsumerGroup:         "test_consumer_group",
 		},
-		saramaSubscriberConfig,
-		kafka.DefaultMarshaler{},
 		watermill.NewStdLogger(false, false),
 	)
 	if err != nil {
@@ -39,9 +39,10 @@ func main() {
 	go process(messages)
 
 	publisher, err := kafka.NewPublisher(
-		[]string{"kafka:9092"},
-		kafka.DefaultMarshaler{},
-		nil, // no custom sarama config
+		kafka.PublisherConfig{
+			Brokers:   []string{"kafka:9092"},
+			Marshaler: kafka.DefaultMarshaler{},
+		},
 		watermill.NewStdLogger(false, false),
 	)
 	if err != nil {

--- a/docs/content/pubsubs/kafka.md
+++ b/docs/content/pubsubs/kafka.md
@@ -33,7 +33,7 @@ You can pass [custom config](https://github.com/Shopify/sarama/blob/master/confi
 When `nil` is passed, default config is used (`DefaultSaramaSubscriberConfig`).
 
 {{% render-md %}}
-{{% load-snippet-partial file="src-link/watermill-kafka/pkg/kafka/config.go" first_line_contains="// DefaultSaramaSubscriberConfig" last_line_contains="return config" padding_after="1" %}}
+{{% load-snippet-partial file="src-link/watermill-kafka/pkg/kafka/subscriber.go" first_line_contains="// DefaultSaramaSubscriberConfig" last_line_contains="return config" padding_after="1" %}}
 {{% /render-md %}}
 
 #### Connecting

--- a/tools/mill/cmd/kafka.go
+++ b/tools/mill/cmd/kafka.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/ThreeDotsLabs/watermill-kafka/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 )
 
 var kafkaCmd = &cobra.Command{
@@ -34,11 +34,11 @@ For the configuration of consuming/producing of the messages, check the help of 
 
 			consumer, err = kafka.NewSubscriber(
 				kafka.SubscriberConfig{
-					Brokers:       brokers,
-					ConsumerGroup: viper.GetString("kafka.consume.consumerGroup"),
+					Brokers:               brokers,
+					Unmarshaler:           kafka.DefaultMarshaler{},
+					OverwriteSaramaConfig: saramaSubscriberConfig,
+					ConsumerGroup:         viper.GetString("kafka.consume.consumerGroup"),
 				},
-				saramaSubscriberConfig,
-				kafka.DefaultMarshaler{},
 				logger,
 			)
 			if err != nil {
@@ -47,7 +47,13 @@ For the configuration of consuming/producing of the messages, check the help of 
 		}
 
 		if cmd.Use == "produce" {
-			producer, err = kafka.NewPublisher(brokers, kafka.DefaultMarshaler{}, nil, logger)
+			producer, err = kafka.NewPublisher(
+				kafka.PublisherConfig{
+					Brokers:   brokers,
+					Marshaler: kafka.DefaultMarshaler{},
+				},
+				logger,
+			)
 			if err != nil {
 				return err
 			}

--- a/tools/mill/go.mod
+++ b/tools/mill/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ThreeDotsLabs/watermill-amqp v1.0.1
 	github.com/ThreeDotsLabs/watermill-googlecloud v1.0.1
 	github.com/ThreeDotsLabs/watermill-io v1.0.1
-	github.com/ThreeDotsLabs/watermill-kafka v1.0.1
+	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/tools/mill/go.sum
+++ b/tools/mill/go.sum
@@ -21,8 +21,8 @@ github.com/ThreeDotsLabs/watermill-googlecloud v1.0.1 h1:8roXIJ9z/wPDguD+nB9SyPe
 github.com/ThreeDotsLabs/watermill-googlecloud v1.0.1/go.mod h1:r2iRWHd5/vetCwLnbYfTyDORydP1ZoPBhEvmvDDx72o=
 github.com/ThreeDotsLabs/watermill-io v1.0.1 h1:xOjCoyr5xdUmc84M2T1bB4OQ4OabvGCXpKjo7W53BYg=
 github.com/ThreeDotsLabs/watermill-io v1.0.1/go.mod h1:yso9y/DzCoEqymrM9jDFHgksaDz83NADML5veQfGgc0=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1 h1:YQgkPKNWF0VrN87ito+CpG15AOsXzG/8fXilTROHpZI=
-github.com/ThreeDotsLabs/watermill-kafka v1.0.1/go.mod h1:rkfdt6PpcQpOGhyublmmGIYUs6qGN3ajYT6P3jYpFYE=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0 h1:+8FeCjF+BgW5b8L7TofMYw8eQUiITF/0evJh38wt3W0=
+github.com/ThreeDotsLabs/watermill-kafka/v2 v2.0.0/go.mod h1:0/RwtDh+LUbVawbSoN2ifZbqhbaW8OK5AJLZ6g7BESE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=


### PR DESCRIPTION
[watermill-kafka v2.0.0](https://github.com/ThreeDotsLabs/watermill-kafka/releases/tag/v2.0.0) introduced breaking changes to the constructors. This PR adopts all examples to the new API.