### PR TITLE
Add thousands separator to benchmark results in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Here's the short version for message size of 16 bytes.
 
 | Pub/Sub              | Publish (messages / s) | Subscribe (messages / s) |
 | -------------------- | ---------------------- | ------------------------ |
-| Kafka (one node)     | 63506                  | 110811                   |
-| Kafka (5 nodes)      | 70252                  | 117529                   |
-| NATS                 | 76208                  | 38169                    |
-| SQL (MySQL)          | 6989                   | 143                      |
-| Google Cloud Pub/Sub | 7416                   | 39591                    |
-| AMQP                 | 2408                   | 10608                    |
-| GoChannel            | 272938                 | 101371                   |
+| Kafka (one node)     | 63,506                 | 110,811                  |
+| Kafka (5 nodes)      | 70,252                 | 117,529                  |
+| NATS                 | 76,208                 | 38,169                   |
+| SQL (MySQL)          | 6,989                  | 143                      |
+| Google Cloud Pub/Sub | 7,416                  | 39,591                   |
+| AMQP                 | 2,408                  | 10,608                   |
+| GoChannel            | 272,938                | 101,371                  |
 
 ## Support
 


### PR DESCRIPTION
The separator just makes it a little easier to understand quickly.