### PR TITLE
add subscribe and publish topics to message context

### DIFF
--- a/message/context.go
+++ b/message/context.go
@@ -10,6 +10,8 @@ const (
 	handlerNameKey    ctxKey = "handler_name"
 	publisherNameKey  ctxKey = "publisher_name"
 	subscriberNameKey ctxKey = "subscriber_name"
+	subscribeTopicKey ctxKey = "subscribe_topic"
+	publishTopicKey   ctxKey = "publish_topic"
 )
 
 func valFromCtx(ctx context.Context, key ctxKey) string {
@@ -30,4 +32,12 @@ func PublisherNameFromCtx(ctx context.Context) string {
 
 func SubscriberNameFromCtx(ctx context.Context) string {
 	return valFromCtx(ctx, subscriberNameKey)
+}
+
+func SubscribeTopicFromCtx(ctx context.Context) string {
+	return valFromCtx(ctx, subscribeTopicKey)
+}
+
+func PublishTopicFromCtx(ctx context.Context) string {
+	return valFromCtx(ctx, publishTopicKey)
 }

--- a/message/context_test.go
+++ b/message/context_test.go
@@ -42,9 +42,9 @@ func TestRouter_Context_Stringer(t *testing.T) {
 	handlerName := "handler_name_stringer_test"
 	router.AddHandler(
 		handlerName,
-		"",
+		"sub-topic",
 		sub,
-		"",
+		"pub-topic",
 		pub,
 		handlerFunc,
 	)
@@ -71,6 +71,8 @@ func TestRouter_Context_Stringer(t *testing.T) {
 	require.Equal(t, handlerName, message.HandlerNameFromCtx(ctx))
 	require.Equal(t, sub.String(), message.SubscriberNameFromCtx(ctx))
 	require.Equal(t, pub.String(), message.PublisherNameFromCtx(ctx))
+	require.Equal(t, "sub-topic", message.SubscribeTopicFromCtx(ctx))
+	require.Equal(t, "pub-topic", message.PublishTopicFromCtx(ctx))
 }
 
 type unnamedMockPublisher struct{}

--- a/message/router.go
+++ b/message/router.go
@@ -544,6 +544,12 @@ func (h *handler) addHandlerContext(messages ...*Message) {
 		if h.subscriberName != "" {
 			ctx = context.WithValue(ctx, subscriberNameKey, h.subscriberName)
 		}
+		if h.subscribeTopic != "" {
+			ctx = context.WithValue(ctx, subscribeTopicKey, h.subscribeTopic)
+		}
+		if h.publishTopic != "" {
+			ctx = context.WithValue(ctx, publishTopicKey, h.publishTopic)
+		}
 		messages[i].SetContext(ctx)
 	}
 }


### PR DESCRIPTION
part of https://github.com/ThreeDotsLabs/watermill-kafka/pull/8
related to https://github.com/ThreeDotsLabs/watermill/issues/69

Exposing subscribe and publish topics through `SubscribeTopicFromCtx` and `PublishTopicFromCtx` in the router.