### PR TITLE
Expose prometheus metrics at /metrics endpoint

### DIFF
--- a/components/metrics/http.go
+++ b/components/metrics/http.go
@@ -26,12 +26,12 @@ func ServeHTTP(addr string, registry *prometheus.Registry) (cancel func()) {
 	})
 	server := http.Server{
 		Addr:    addr,
-		Handler: handler,
+		Handler: router,
 	}
 
 	go func() {
 		err := server.ListenAndServe()
-		if err != nil {
+		if err != http.ErrServerClosed {
 			panic(err)
 		}
 	}()

--- a/components/metrics/http.go
+++ b/components/metrics/http.go
@@ -36,11 +36,5 @@ func ServeHTTP(addr string, registry *prometheus.Registry) (cancel func()) {
 		}
 	}()
 
-	wait := make(chan struct{})
-	go func() {
-		<-wait
-		server.Close()
-	}()
-
-	return func() { close(wait) }
+	return func() { _ = server.Close() }
 }

--- a/components/metrics/http_test.go
+++ b/components/metrics/http_test.go
@@ -1,0 +1,51 @@
+package metrics_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/components/metrics"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateRegistryAndServeHTTP_metrics_endpoint(t *testing.T) {
+	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8080")
+	defer cancel()
+	err := reg.Register(prometheus.NewBuildInfoCollector())
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "registration of prometheus build info collector failed"))
+	}
+
+	resp, err := http.DefaultClient.Get("http://localhost:8080/metrics")
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "call to metrics endpoint failed"))
+	}
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestCreateRegistryAndServeHTTP_unknown_endpoint(t *testing.T) {
+	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8080")
+	defer cancel()
+	err := reg.Register(prometheus.NewBuildInfoCollector())
+	if err != nil {
+		t.Error(errors.Wrap(err, "registration of prometheus build info collector failed"))
+	}
+
+	resp, err := http.DefaultClient.Get("http://localhost:8080/unknown")
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "call to unknown endpoint failed"))
+	}
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/components/metrics/http_test.go
+++ b/components/metrics/http_test.go
@@ -31,14 +31,14 @@ func TestCreateRegistryAndServeHTTP_metrics_endpoint(t *testing.T) {
 }
 
 func TestCreateRegistryAndServeHTTP_unknown_endpoint(t *testing.T) {
-	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8090")
+	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8091")
 	defer cancel()
 	err := reg.Register(prometheus.NewBuildInfoCollector())
 	if err != nil {
 		t.Error(errors.Wrap(err, "registration of prometheus build info collector failed"))
 	}
 
-	resp, err := http.DefaultClient.Get("http://localhost:8090/unknown")
+	resp, err := http.DefaultClient.Get("http://localhost:8091/unknown")
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/components/metrics/http_test.go
+++ b/components/metrics/http_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func TestCreateRegistryAndServeHTTP_metrics_endpoint(t *testing.T) {
-	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8080")
+	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8090")
 	defer cancel()
 	err := reg.Register(prometheus.NewBuildInfoCollector())
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "registration of prometheus build info collector failed"))
 	}
 
-	resp, err := http.DefaultClient.Get("http://localhost:8080/metrics")
+	resp, err := http.DefaultClient.Get("http://localhost:8090/metrics")
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -31,14 +31,14 @@ func TestCreateRegistryAndServeHTTP_metrics_endpoint(t *testing.T) {
 }
 
 func TestCreateRegistryAndServeHTTP_unknown_endpoint(t *testing.T) {
-	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8080")
+	reg, cancel := metrics.CreateRegistryAndServeHTTP(":8090")
 	defer cancel()
 	err := reg.Register(prometheus.NewBuildInfoCollector())
 	if err != nil {
 		t.Error(errors.Wrap(err, "registration of prometheus build info collector failed"))
 	}
 
-	resp, err := http.DefaultClient.Get("http://localhost:8080/unknown")
+	resp, err := http.DefaultClient.Get("http://localhost:8090/unknown")
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/components/metrics/http_test.go
+++ b/components/metrics/http_test.go
@@ -3,6 +3,7 @@ package metrics_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/components/metrics"
 	"github.com/pkg/errors"
@@ -17,7 +18,7 @@ func TestCreateRegistryAndServeHTTP_metrics_endpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "registration of prometheus build info collector failed"))
 	}
-
+	waitServerReady(t, "http://localhost:8090")
 	resp, err := http.DefaultClient.Get("http://localhost:8090/metrics")
 	if resp != nil {
 		defer resp.Body.Close()
@@ -37,7 +38,7 @@ func TestCreateRegistryAndServeHTTP_unknown_endpoint(t *testing.T) {
 	if err != nil {
 		t.Error(errors.Wrap(err, "registration of prometheus build info collector failed"))
 	}
-
+	waitServerReady(t, "http://localhost:8091")
 	resp, err := http.DefaultClient.Get("http://localhost:8091/unknown")
 	if resp != nil {
 		defer resp.Body.Close()
@@ -48,4 +49,17 @@ func TestCreateRegistryAndServeHTTP_unknown_endpoint(t *testing.T) {
 	}
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// server might have small delay before being able to server traffic
+func waitServerReady(t *testing.T, addr string) {
+	for i := 0; i < 50; i++ {
+		_, err := http.DefaultClient.Get(addr)
+		// assume server ready when no err anymore
+		if err == nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+		continue
+	}
 }

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	
+
 	"github.com/lithammer/shortuuid/v3"
 
 	"github.com/ThreeDotsLabs/watermill"


### PR DESCRIPTION
The chi.Router is not used and I believe it is not intentional.
I have added tests to cover the expected behaviour. `go fmt` has added a small diff in `pubsub.go`.

Also out of curiosity, is there any benefit to do
```
	wait := make(chan struct{})
	go func() {
		<-wait
		server.Close()
	}()

	return func() { close(wait) }
```
instead of directly? 
```
	return func() { server.Close() }
```
Thanks