### PR TITLE
Close all subscribers in TestConcurrentSubscribe

### DIFF
--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -271,6 +271,8 @@ func TestConcurrentSubscribe(
 		sub = createMultipliedSubscriber(t, pubSubConstructor, subscribersCount)
 	}
 
+	defer closePubSub(t, pub, sub)
+
 	messages, err := sub.Subscribe(context.Background(), topicName)
 	require.NoError(t, err)
 


### PR DESCRIPTION
I was running into some errors when building a new subscriber due to subscribers continuing to log after a test has finished.

This changes ensures that the created multi-subscriber will be closed at the end of `TestConcurrentSubscribe`