### PR TITLE
Add Forwarder component

### DIFF
--- a/components/forwarder/config.go
+++ b/components/forwarder/config.go
@@ -1,0 +1,6 @@
+package forwarder
+
+type Config struct {
+	// ForwarderTopic is a topic on which the forwarder will be listening to enveloped messages to forward.
+	ForwarderTopic string
+}

--- a/components/forwarder/config.go
+++ b/components/forwarder/config.go
@@ -2,5 +2,12 @@ package forwarder
 
 type Config struct {
 	// ForwarderTopic is a topic on which the forwarder will be listening to enveloped messages to forward.
+	// Defaults to `forwarder_topic`.
 	ForwarderTopic string
+}
+
+func (c *Config) setDefaults() {
+	if c.ForwarderTopic == "" {
+		c.ForwarderTopic = "forwarder_topic"
+	}
 }

--- a/components/forwarder/envelope.go
+++ b/components/forwarder/envelope.go
@@ -1,0 +1,46 @@
+package forwarder
+
+import (
+	"encoding/json"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/pkg/errors"
+)
+
+// messageEnvelope wraps Watermill message and contains destination topic.
+type messageEnvelope struct {
+	DestinationTopic string `json:"destination_topic"`
+
+	UUID     string            `json:"uuid"`
+	Payload  []byte            `json:"payload"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+func wrapMessageInEnvelope(destinationTopic string, msg *message.Message) (*message.Message, error) {
+	envelope := messageEnvelope{
+		DestinationTopic: destinationTopic,
+		UUID:             msg.UUID,
+		Payload:          msg.Payload,
+		Metadata:         msg.Metadata,
+	}
+
+	envelopedMessage, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal message")
+	}
+
+	return message.NewMessage(watermill.NewUUID(), envelopedMessage), nil
+}
+
+func unwrapMessageFromEnvelope(msg *message.Message) (destinationTopic string, unwrappedMsg *message.Message, err error) {
+	envelopedMsg := messageEnvelope{}
+	if err := json.Unmarshal(msg.Payload, &envelopedMsg); err != nil {
+		return "", nil, errors.Wrap(err, "cannot unmarshal message wrapped in envelope")
+	}
+
+	watermillMessage := message.NewMessage(envelopedMsg.UUID, envelopedMsg.Payload)
+	watermillMessage.Metadata = envelopedMsg.Metadata
+
+	return envelopedMsg.DestinationTopic, watermillMessage, nil
+}

--- a/components/forwarder/envelope_test.go
+++ b/components/forwarder/envelope_test.go
@@ -1,0 +1,32 @@
+package forwarder
+
+import (
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvelope(t *testing.T) {
+	expectedUUID := watermill.NewUUID()
+	expectedPayload := message.Payload("msg content")
+	expectedMetadata := message.Metadata{"key": "value"}
+	expectedDestinationTopic := "dest_topic"
+
+	msg := message.NewMessage(expectedUUID, expectedPayload)
+	msg.Metadata = expectedMetadata
+
+	wrappedMsg, err := wrapMessageInEnvelope(expectedDestinationTopic, msg)
+	require.NoError(t, err)
+	require.NotNil(t, wrappedMsg)
+
+	destinationTopic, unwrappedMsg, err := unwrapMessageFromEnvelope(wrappedMsg)
+	require.NoError(t, err)
+	require.NotNil(t, unwrappedMsg)
+	assert.Equal(t, expectedUUID, unwrappedMsg.UUID)
+	assert.Equal(t, expectedPayload, unwrappedMsg.Payload)
+	assert.Equal(t, expectedMetadata, unwrappedMsg.Metadata)
+	assert.Equal(t, expectedDestinationTopic, destinationTopic)
+}

--- a/components/forwarder/forwarder.go
+++ b/components/forwarder/forwarder.go
@@ -1,0 +1,80 @@
+package forwarder
+
+import (
+	"context"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/pkg/errors"
+)
+
+// Forwarder subscribes to the topic provided in the config and publishes them to the destination topic embedded in the enveloped message.
+type Forwarder struct {
+	router    *message.Router
+	publisher message.Publisher
+	config    Config
+}
+
+// NewForwarder creates a forwarder which will subscribe to the topic provided in the provided config using the provided subscriber.
+// It will publish messages received on this subscription to the destination topic embedded in the enveloped message using the provided publisher.
+//
+// Provided subscriber and publisher can be from different Watermill Pub/Sub implementations, i.e. MySQL subscriber and Google Pub/Sub publisher.
+func NewForwarder(subscriber message.Subscriber, publisher message.Publisher, logger watermill.LoggerAdapter, config Config) (*Forwarder, error) {
+	router, err := message.NewRouter(message.RouterConfig{}, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &Forwarder{router, publisher, config}
+
+	router.AddNoPublisherHandler(
+		"events_forwarder",
+		config.ForwarderTopic,
+		subscriber,
+		f.forwardMessage,
+	)
+
+	return f, nil
+}
+
+// Run runs forwarder's handler responsible for forwarding messages.
+// This call is blocking while the forwarder is running.
+// ctx will be propagated to the forwarder's subscription.
+//
+// To stop Run() you should call Close() on the forwarder.
+func (f *Forwarder) Run(ctx context.Context) error {
+	return f.router.Run(ctx)
+}
+
+// Close stops forwarder's handler.
+func (f *Forwarder) Close() error {
+	return f.router.Close()
+}
+
+// Running returns channel which is closed when the forwarder is running.
+func (f *Forwarder) Running() chan struct{} {
+	return f.router.Running()
+}
+
+// DecoratePublisher is a helper method which decorates a given publisher so when it publishes messages,
+// it envelopes them and publish directly to the forwarder's topic provided in the forwarder's config.
+//
+// Enveloping means that the message is put into the generic envelope containing the original message
+// and a destination topic taken from publisher `Publish` method. The destination topic is used later
+// by the forwarder to forward it to a specific topic.
+func (f *Forwarder) DecoratePublisher(publisher message.Publisher) (message.Publisher, error) {
+	return NewPublisherDecorator(publisher, f.config), nil
+}
+
+func (f *Forwarder) forwardMessage(msg *message.Message) error {
+	destTopic, unwrappedMsg, err := unwrapMessageFromEnvelope(msg)
+	if err != nil {
+		return errors.Wrap(err, "cannot unwrap message from envelope")
+	}
+
+	if err := f.publisher.Publish(destTopic, unwrappedMsg); err != nil {
+		return errors.Wrap(err, "cannot publish message")
+	}
+
+	return nil
+}

--- a/components/forwarder/forwarder_test.go
+++ b/components/forwarder/forwarder_test.go
@@ -39,8 +39,7 @@ func TestForwarder(t *testing.T) {
 	}()
 
 	// Decorate publisherIn so it envelopes messages and publishes them to the forwarder topic.
-	decoratedPublisherIn, err := f.DecoratePublisher(publisherIn)
-	require.NoError(t, err)
+	decoratedPublisherIn := f.DecoratePublisher(publisherIn)
 
 	outTopic := "out_topic"
 	outMessages := listenOnOutTopic(t, ctx, subscriberOut, outTopic)
@@ -48,7 +47,7 @@ func TestForwarder(t *testing.T) {
 	// Send a message using decorated publisher.
 	sentMessage := message.NewMessage(watermill.NewUUID(), message.Payload("message payload"))
 	sentMessage.Metadata = message.Metadata{"key": "value"}
-	err = decoratedPublisherIn.Publish(outTopic, sentMessage)
+	err := decoratedPublisherIn.Publish(outTopic, sentMessage)
 	require.NoError(t, err)
 
 	// Wait for a message sent using publisherIn on subscriberOut.

--- a/components/forwarder/forwarder_test.go
+++ b/components/forwarder/forwarder_test.go
@@ -1,0 +1,111 @@
+package forwarder_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/components/forwarder"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForwarder tests forwarding messages from PubSubIn to PubSubOut (which are GoChannel implementation underneath).
+func TestForwarder(t *testing.T) {
+	logger := watermill.NewStdLogger(true, true)
+
+	// Create a set of publisher and subscribers for both In and Out Pub/Subs.
+	publisherIn, subscriberIn := newPubSubIn(logger)
+	publisherOut, subscriberOut := newPubSubOut(logger)
+	defer func() {
+		require.NoError(t, publisherIn.Close())
+		require.NoError(t, subscriberIn.Close())
+		require.NoError(t, publisherOut.Close())
+		require.NoError(t, subscriberOut.Close())
+	}()
+
+	// Create test context with a 5 seconds timeout so it will close any subscriptions/handlers running in the background
+	// in case of too long test execution.
+	ctx, cancelCtx := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancelCtx()
+
+	// Setup a forwarder to forward messages from Pub/Sub In to Out by passing subscriberIn and publisherOut.
+	f := setupForwarder(t, ctx, subscriberIn, publisherOut, logger)
+	defer func() {
+		require.NoError(t, f.Close())
+	}()
+
+	// Decorate publisherIn so it envelopes messages and publishes them to the forwarder topic.
+	decoratedPublisherIn, err := f.DecoratePublisher(publisherIn)
+	require.NoError(t, err)
+
+	outTopic := "out_topic"
+	outMessages := listenOnOutTopic(t, ctx, subscriberOut, outTopic)
+
+	// Send a message using decorated publisher.
+	sentMessage := message.NewMessage(watermill.NewUUID(), message.Payload("message payload"))
+	sentMessage.Metadata = message.Metadata{"key": "value"}
+	err = decoratedPublisherIn.Publish(outTopic, sentMessage)
+	require.NoError(t, err)
+
+	// Wait for a message sent using publisherIn on subscriberOut.
+	receivedMessage := <-outMessages
+	require.NotNil(t, receivedMessage)
+	receivedMessage.Ack()
+
+	assert.Equal(t, sentMessage.UUID, receivedMessage.UUID)
+	assert.Equal(t, sentMessage.Payload, receivedMessage.Payload)
+	assert.Equal(t, sentMessage.Metadata, receivedMessage.Metadata)
+}
+
+type PubSubInPublisher struct {
+	message.Publisher
+}
+type PubSubInSubscriber struct {
+	message.Subscriber
+}
+
+type PubSubOutPublisher struct {
+	message.Publisher
+}
+type PubSubOutSubscriber struct {
+	message.Subscriber
+}
+
+func newPubSubIn(logger watermill.LoggerAdapter) (PubSubInPublisher, PubSubInSubscriber) {
+	channelPubSub := gochannel.NewGoChannel(gochannel.Config{}, logger)
+	return PubSubInPublisher{channelPubSub}, PubSubInSubscriber{channelPubSub}
+}
+
+func newPubSubOut(logger watermill.LoggerAdapter) (PubSubOutPublisher, PubSubOutSubscriber) {
+	channelPubSub := gochannel.NewGoChannel(gochannel.Config{}, logger)
+	return PubSubOutPublisher{channelPubSub}, PubSubOutSubscriber{channelPubSub}
+}
+
+func setupForwarder(t *testing.T, ctx context.Context, subscriberIn PubSubInSubscriber, publisherOut PubSubOutPublisher, logger watermill.LoggerAdapter) *forwarder.Forwarder {
+	forwarderConfig := forwarder.Config{ForwarderTopic: "forwarder_topic"}
+	f, err := forwarder.NewForwarder(subscriberIn, publisherOut, logger, forwarderConfig)
+	require.NoError(t, err)
+
+	go func() {
+		require.NoError(t, f.Run(ctx))
+	}()
+
+	select {
+	case <-f.Running():
+	case <-ctx.Done():
+		t.Error("forwarder not running")
+	}
+
+	return f
+}
+
+func listenOnOutTopic(t *testing.T, ctx context.Context, subscriberOut PubSubOutSubscriber, outTopic string) <-chan *message.Message {
+	messagesCh, err := subscriberOut.Subscribe(ctx, outTopic)
+	require.NoError(t, err)
+
+	return messagesCh
+}

--- a/components/forwarder/publisher.go
+++ b/components/forwarder/publisher.go
@@ -2,7 +2,6 @@ package forwarder
 
 import (
 	"github.com/ThreeDotsLabs/watermill/message"
-
 	"github.com/pkg/errors"
 )
 

--- a/components/forwarder/publisher.go
+++ b/components/forwarder/publisher.go
@@ -1,0 +1,43 @@
+package forwarder
+
+import (
+	"github.com/ThreeDotsLabs/watermill/message"
+
+	"github.com/pkg/errors"
+)
+
+// PublisherDecorator changes `Publish` method behavior so it wraps a sent message in an envelope
+// and sends it to the forwarder topic provided in the config.
+type PublisherDecorator struct {
+	wrappedPublisher message.Publisher
+	config           Config
+}
+
+func NewPublisherDecorator(publisher message.Publisher, config Config) *PublisherDecorator {
+	return &PublisherDecorator{
+		wrappedPublisher: publisher,
+		config:           config,
+	}
+}
+
+func (p *PublisherDecorator) Publish(topic string, messages ...*message.Message) error {
+	envelopedMessages := make([]*message.Message, 0, len(messages))
+	for _, msg := range messages {
+		envelopedMsg, err := wrapMessageInEnvelope(topic, msg)
+		if err != nil {
+			return errors.Wrapf(err, "cannot wrap message, target topic: '%s', uuid: '%s'", topic, msg.UUID)
+		}
+
+		envelopedMessages = append(envelopedMessages, envelopedMsg)
+	}
+
+	if err := p.wrappedPublisher.Publish(p.config.ForwarderTopic, envelopedMessages...); err != nil {
+		return errors.Wrapf(err, "cannot publish messages to forwarder topic: '%s'", p.config.ForwarderTopic)
+	}
+
+	return nil
+}
+
+func (p *PublisherDecorator) Close() error {
+	return p.wrappedPublisher.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,15 @@ require (
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gogo/protobuf v1.2.1
-	github.com/golang/protobuf v1.3.1
+	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/lithammer/shortuuid/v3 v3.0.4
 	github.com/oklog/ulid v1.3.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.0.0
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
+	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
 )
 
 go 1.11

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -62,6 +64,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -69,7 +73,12 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5 h1:mzjBh+S5frKOsOBobWIMAbXavqjmgO17k/2puhcFR94=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
+golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/message/router/middleware/poison_test.go
+++ b/message/router/middleware/poison_test.go
@@ -2,11 +2,12 @@ package middleware_test
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message/subscriber"
 	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
-	"testing"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 


### PR DESCRIPTION
`Forwarder` is meant to automatically forward messages from one Pub/Sub to another (let's say _Input_ and _Output_), listening on a single _Input_ forwarder topic. Messages are put into an envelope when sent with a decorated publisher to _Input_ and then unwrapped by the forwarder and sent to _Output_ on a destination topic taken from the envelope. 

`Forwarder` uses `Router` underneath and implements its API. Additionally it has `DecoratePublisher` helper method which decorates publisher meant to send messages to _Input PubSub_. 