### PR TITLE
Extend message struct to include a raw interface

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -32,6 +32,9 @@ type Message struct {
 	// Payload is message's payload.
 	Payload Payload
 
+	// Interface to store user data.
+	UserData interface{}
+
 	// ack is closed, when acknowledge is received.
 	ack chan struct{}
 	// noACk is closed, when negative acknowledge is received.
@@ -180,5 +183,10 @@ func (m *Message) Copy() *Message {
 	for k, v := range m.Metadata {
 		msg.Metadata.Set(k, v)
 	}
+
+	// Copy the user data to the message passed to the next
+	// handler
+	msg.UserData = m.UserData
+
 	return msg
 }


### PR DESCRIPTION
Add a new field to the message struct in order to pass user data such as a struct of pointers.
Despite the data can be stored on the message payload it has two disadvantages:
1) It forces the user to marshall/unmarshall the data each time that the message is passed in the pipeline.
2) Data such as signaling channels or pointers can not be cast to a []byte.

The user data approach is valid for routers running inside the same process.

Signed-off-by: Daniel Canessa <daniel.canessa@hpe.com>