### PR TITLE
Initialize subscribers for each consumer group

### DIFF
--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -1099,6 +1099,9 @@ func generateConsumerGroup(t *testing.T, pubSubConstructor ConsumerGroupPubSubCo
 	// create a pubsub to ensure that the consumer group exists
 	// for those providers that require subscription before publishing messages (e.g. Google Cloud PubSub)
 	pub, sub := pubSubConstructor(t, groupName)
+	if subInitializer, ok := sub.(message.SubscribeInitializer); ok {
+		require.NoError(t, subInitializer.SubscribeInitialize(topicName))
+	}
 	_, err := sub.Subscribe(context.Background(), topicName)
 	require.NoError(t, err)
 	closePubSub(t, pub, sub)


### PR DESCRIPTION
While working on an implementation for #126 (PostgreSQL driver with `SKIP LOCKED`), I found it necessary to initialize for each subscriber group. Therefore I needed to add the `SubscribeInitialize` in `generateConsumerGroup`, which is used by the test `TestConsumerGroups`.