### PR TITLE
Return the handler instance created within AddNoPublisherHandler

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -279,12 +279,12 @@ func (r *Router) AddNoPublisherHandler(
 	subscribeTopic string,
 	subscriber Subscriber,
 	handlerFunc NoPublishHandlerFunc,
-) {
+) *Handler {
 	handlerFuncAdapter := func(msg *Message) ([]*Message, error) {
 		return nil, handlerFunc(msg)
 	}
 
-	r.AddHandler(handlerName, subscribeTopic, subscriber, "", disabledPublisher{}, handlerFuncAdapter)
+	return r.AddHandler(handlerName, subscribeTopic, subscriber, "", disabledPublisher{}, handlerFuncAdapter)
 }
 
 // Run runs all plugins and handlers and starts subscribing to provided topics.


### PR DESCRIPTION
The handler instance is currently returned from `AddHandler` but not `AddNoPublisherHandler` . This means handlers created by `AddNoPublisherHandler` cant have handler specific middlewares added. I couldn't tell if this was by design or not. This should be a non breaking change.