### PR TITLE
Mark consumer groups as supported

### DIFF
--- a/docs/content/pubsubs/firestore.md
+++ b/docs/content/pubsubs/firestore.md
@@ -33,7 +33,7 @@ Firestore documentation: <https://firebase.google.com/docs/firestore/>
 
 | Feature             | Implements | Note |
 | -------             | ---------- | ---- |
-| ConsumerGroups      | no         |      |
+| ConsumerGroups      | yes        |      |
 | ExactlyOnceDelivery | no         |      |
 | GuaranteedOrder     | no         |      |
 | Persistent          | yes        |      |


### PR DESCRIPTION
Consumer groups are currently marked as supported here:
 https://github.com/ThreeDotsLabs/watermill-firestore/blob/master/pkg/firestore/pubsub_test.go#L53