### PR TITLE
Support for dynamic handler in router

### DIFF
--- a/message/pubsub.go
+++ b/message/pubsub.go
@@ -33,6 +33,15 @@ type Subscriber interface {
 	Close() error
 }
 
+type DynamicSubscriber interface {
+	// Embeds subscriber interface
+	Subscriber
+	// DynamicSubscribe returns output channel with messages from provided topic,
+	// and also returns close channel to stop subscription from a topic.
+	// Implements same Subscribe functionality present in Subscriber interface
+	DynamicSubscribe(ctx context.Context, topic string) (chan bool, <-chan *Message, error)
+}
+
 type SubscribeInitializer interface {
 	// SubscribeInitialize can be called to initialize subscribe before consume.
 	// When calling Subscribe before Publish, SubscribeInitialize should be not required.


### PR DESCRIPTION
Router.Run(ctx) runs all plugins and handlers and subscribes to topics,
but doesnt allow to add/remove new handlers once it starts running.
In run-time scenarios, sometimes it is necessary to add new subscriptions
and remove them, without disturbing the rest of subscriptors and
pub/sub channels.

This change allows for GoChannels to add dynamic subscribers
that can get unsubscribed from their topics on closing respective channel.

It also allows for routers to add and remove handlers (and their corresponding
dynamic subscribers) even after the router starts running.
To avoid closing publishers when removing dynamic subscribers,
the dynamic handlers are of type no publisher handlers.

To implement dynamic subscriber interface, the subscriber must also
implement DynamicSubscribe method, returning the same Subscribe output
plus a close (to trigger unsubscriber logic) channel