### PR TITLE
Pass Context to Forwarder's wrapped message

### DIFF
--- a/components/forwarder/envelope.go
+++ b/components/forwarder/envelope.go
@@ -51,7 +51,10 @@ func wrapMessageInEnvelope(destinationTopic string, msg *message.Message) (*mess
 		return nil, errors.Wrap(err, "cannot marshal a message")
 	}
 
-	return message.NewMessage(watermill.NewUUID(), envelopedMessage), nil
+	wrappedMsg := message.NewMessage(watermill.NewUUID(), envelopedMessage)
+	wrappedMsg.SetContext(msg.Context())
+
+	return wrappedMsg, nil
 }
 
 func unwrapMessageFromEnvelope(msg *message.Message) (destinationTopic string, unwrappedMsg *message.Message, err error) {

--- a/components/forwarder/envelope_test.go
+++ b/components/forwarder/envelope_test.go
@@ -1,6 +1,7 @@
 package forwarder
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill"
@@ -15,12 +16,18 @@ func TestEnvelope(t *testing.T) {
 	expectedMetadata := message.Metadata{"key": "value"}
 	expectedDestinationTopic := "dest_topic"
 
+	ctx := context.WithValue(context.Background(), "key", "value")
+
 	msg := message.NewMessage(expectedUUID, expectedPayload)
 	msg.Metadata = expectedMetadata
+	msg.SetContext(ctx)
 
 	wrappedMsg, err := wrapMessageInEnvelope(expectedDestinationTopic, msg)
 	require.NoError(t, err)
 	require.NotNil(t, wrappedMsg)
+	v, ok := wrappedMsg.Context().Value("key").(string)
+	require.True(t, ok)
+	require.Equal(t, "value", v)
 
 	destinationTopic, unwrappedMsg, err := unwrapMessageFromEnvelope(wrappedMsg)
 	require.NoError(t, err)


### PR DESCRIPTION
I've been using Forwarder's Publisher with one other Publisher wrapper (for setting correlation ID from message's Context). It turned out the order of wrapping matters: because the message's Context is not propagated.

This is a very specific case because the context will be lost anyway while marshaling the envelope. But for this one scenario, I guess it makes sense.