### PR TITLE
Changes to Pubsub Test for ExactlyOnce

### DIFF
--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -886,6 +886,13 @@ func TestMessageCtx(
 	tCtx TestContext,
 	pubSubConstructor PubSubConstructor,
 ) {
+	if tCtx.Features.ExactlyOnceDelivery {
+		// with ExactlyOnce delivery (at least as implemented by NATS jetstream)
+		// the second message will never be received because the broker deduplicates
+		// by message ID.
+		t.Skip("ExactlyOnceDelivery test is not supported yet")
+	}
+
 	pub, sub := pubSubConstructor(t)
 	defer closePubSub(t, pub, sub)
 

--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -583,7 +583,7 @@ func TestContinueAfterSubscribeClose(
 	tCtx TestContext,
 	createPubSub PubSubConstructor,
 ) {
-	if !tCtx.Features.Persistent {
+	if tCtx.Features.ExactlyOnceDelivery {
 		t.Skip("ExactlyOnceDelivery test is not supported yet")
 	}
 

--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -583,6 +583,10 @@ func TestContinueAfterSubscribeClose(
 	tCtx TestContext,
 	createPubSub PubSubConstructor,
 ) {
+	if !tCtx.Features.Persistent {
+		t.Skip("Non-Persistent is not supported yet")
+	}
+
 	if tCtx.Features.ExactlyOnceDelivery {
 		t.Skip("ExactlyOnceDelivery test is not supported yet")
 	}


### PR DESCRIPTION
Noticed one bad feature check (skipping if Persistent enabled, though message indicates ExactlyOnce intended).

Also added another to skip TestMessageCtx - this can also be addressed by calling publish the second time with a new message ID but I am not sure if that would invalidate the test in other situation?