### PR TITLE
[Added] Router handlers method for router plugins

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -208,6 +208,17 @@ func (r *Router) AddSubscriberDecorators(dec ...SubscriberDecorator) {
 	r.subscriberDecorators = append(r.subscriberDecorators, dec...)
 }
 
+// Handlers returns all registered handlers.
+func (r *Router) Handlers() map[string]HandlerFunc {
+	handlers := map[string]HandlerFunc{}
+
+	for handlerName, handler := range r.handlers {
+		handlers[handlerName] = handler.handlerFunc
+	}
+
+	return handlers
+}
+
 // DuplicateHandlerNameError is sent in a panic when you try to add a second handler with the same name.
 type DuplicateHandlerNameError struct {
 	HandlerName string


### PR DESCRIPTION
Exposed the registered router handlers to be used by a router plugin in order to allow use cases such as message reprocessing described in issue #288