### PR TITLE
Update Recoverer MW

### DIFF
--- a/message/router/middleware/recoverer.go
+++ b/message/router/middleware/recoverer.go
@@ -5,7 +5,6 @@ import (
 	"runtime/debug"
 
 	"github.com/ThreeDotsLabs/watermill/message"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
 
@@ -25,8 +24,7 @@ func Recoverer(h message.HandlerFunc) message.HandlerFunc {
 	return func(event *message.Message) (events []*message.Message, err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				panicErr := errors.WithStack(RecoveredPanicError{V: r, Stacktrace: string(debug.Stack())})
-				err = multierror.Append(err, panicErr)
+				err = errors.WithStack(RecoveredPanicError{V: r, Stacktrace: string(debug.Stack())})
 			}
 		}()
 

--- a/message/router/middleware/recoverer_test.go
+++ b/message/router/middleware/recoverer_test.go
@@ -7,14 +7,15 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecoverer(t *testing.T) {
 	h := middleware.Recoverer(func(msg *message.Message) (messages []*message.Message, e error) {
-		panic("foo")
+		panic(nil)
 	})
 
 	_, err := h(message.NewMessage("1", nil))
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "message/router/middleware/recoverer.go") // stacktrace part
 }

--- a/message/router/middleware/recoverer_test.go
+++ b/message/router/middleware/recoverer_test.go
@@ -10,12 +10,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRecoverer(t *testing.T) {
+func TestRecoverer_Panic(t *testing.T) {
+	h := middleware.Recoverer(func(msg *message.Message) (messages []*message.Message, e error) {
+		panic("foo")
+	})
+
+	_, err := h(message.NewMessage("1", nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "message/router/middleware/recoverer.go") // stacktrace part
+}
+
+func TestRecoverer_PanicNil(t *testing.T) {
 	h := middleware.Recoverer(func(msg *message.Message) (messages []*message.Message, e error) {
 		panic(nil)
 	})
 
 	_, err := h(message.NewMessage("1", nil))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "message/router/middleware/recoverer.go") // stacktrace part
+}
+
+func TestRecoverer_NoPanic(t *testing.T) {
+	h := middleware.Recoverer(func(msg *message.Message) (messages []*message.Message, e error) {
+		return nil, nil
+	})
+
+	_, err := h(message.NewMessage("1", nil))
+	require.NoError(t, err)
 }


### PR DESCRIPTION
- [Remove redundant multierror from Recoverer MW](https://github.com/ThreeDotsLabs/watermill/commit/e5fcffc5711e8cdc4f7f27947f3a2fe915f148cd)
- [Recover panics with nil value](https://github.com/ThreeDotsLabs/watermill/commit/a3f909914606b5d27aaa002a617132796b3c55b4)