### PR TITLE
example > basic > 3-router: reorder middlewares

### DIFF
--- a/_examples/basic/3-router/main.go
+++ b/_examples/basic/3-router/main.go
@@ -32,8 +32,9 @@ func main() {
 
 	// Router level middleware are executed for every message sent to the router
 	router.AddMiddleware(
-		// CorrelationID will copy the correlation id from the incoming message's metadata to the produced messages
-		middleware.CorrelationID,
+		// Recoverer handles panics from handlers.
+		// In this case, it passes them as errors to the Retry middleware.
+		middleware.Recoverer,
 
 		// The handler function is retried if it returns an error.
 		// After MaxRetries, the message is Nacked and it's up to the PubSub to resend it.
@@ -42,10 +43,9 @@ func main() {
 			InitialInterval: time.Millisecond * 100,
 			Logger:          logger,
 		}.Middleware,
-
-		// Recoverer handles panics from handlers.
-		// In this case, it passes them as errors to the Retry middleware.
-		middleware.Recoverer,
+		
+		// CorrelationID will copy the correlation id from the incoming message's metadata to the produced messages
+		middleware.CorrelationID,
 	)
 
 	// For simplicity, we are using the gochannel Pub/Sub here,


### PR DESCRIPTION
Looking at the source code & examples I see that middlewares are executed top to bottom. In the comments here we see that Recoverer should happen before Retry. This should help folks that look at these examples.