### PR TITLE
Update pubsub test setting

### DIFF
--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -315,7 +315,7 @@ func TestConcurrentSubscribeMultipleTopics(
 	defer closePubSub(t, pub, sub)
 
 	messagesCount := 100
-	topicsCount := 50
+	topicsCount := 20
 
 	if testing.Short() {
 		messagesCount = 50
@@ -357,7 +357,7 @@ func TestConcurrentSubscribeMultipleTopics(
 			if err != nil {
 				t.Error(err)
 			}
-			topicMessages, _ := bulkRead(tCtx, messages, len(messagesToPublish), defaultTimeout)
+			topicMessages, _ := bulkRead(tCtx, messages, len(messagesToPublish), defaultTimeout*5)
 
 			receivedMessagesCh <- topicMessages
 		}()


### PR DESCRIPTION
Update pubsub test setting (`TestConcurrentSubscribeMultipleTopics`) to resolve timeout error in GitHub Actions:
1. Reduced `topicsCount` from 50 to 20
2. Increased `bulkRead` timeout from `defaultTimeout` (15 secs) to `defaultTimeout*5` (75 secs)