### PR TITLE
correct link of doc about pub/sub implementation supported by watermill

### DIFF
--- a/_examples/basic/5-cqrs-protobuf/main.go
+++ b/_examples/basic/5-cqrs-protobuf/main.go
@@ -174,8 +174,8 @@ func main() {
 	logger := watermill.NewStdLogger(false, false)
 	cqrsMarshaler := cqrs.ProtobufMarshaler{}
 
-	// You can use any Pub/Sub implementation from here: https://watermill.io/docs/pub-sub-implementations/
-	// Detailed RabbitMQ implementation: https://watermill.io/docs/pub-sub-implementations/#rabbitmq-amqp
+	// You can use any Pub/Sub implementation from here: https://watermill.io/pubsubs/
+	// Detailed RabbitMQ implementation: https://watermill.io/pubsubs/amqp/
 	// Commands will be send to queue, because they need to be consumed once.
 	commandsAMQPConfig := amqp.NewDurableQueueConfig(amqpAddress)
 	commandsPublisher, err := amqp.NewPublisher(commandsAMQPConfig, logger)

--- a/pubsub/doc.go
+++ b/pubsub/doc.go
@@ -1,6 +1,6 @@
 // Infrastructure directory contains Pub/Subs implementations.
 //
-// Detailed Pub/Subs docs: https://watermill.io/docs/pub-sub-implementations/
+// Detailed Pub/Subs docs: https://watermill.io/pubsubs/
 // Getting started guide: https://watermill.io/docs/getting-started/
 
 package pubsub

--- a/pubsub/gochannel/doc.go
+++ b/pubsub/gochannel/doc.go
@@ -1,5 +1,5 @@
 // This is just the simplest Pub/Sub implementation
 //
-// All Pub/Sub implementations can be found at https://watermill.io/docs/pub-sub-implementations/
+// All Pub/Sub implementations can be found at https://watermill.io/pubsubs/
 
 package gochannel


### PR DESCRIPTION
## context

in my understanding, `https://watermill.io/docs/pub-sub-implementations/` is expired now.
so I correct existing link. is this correct? 👓 

## note

I'm not familiar with watermill. could you confirm at your convenience?