### PR TITLE
fix: router new logger panic

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -91,6 +91,10 @@ func NewRouter(config RouterConfig, logger watermill.LoggerAdapter) (*Router, er
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
+	if logger == nil {
+		logger = watermill.NopLogger{}
+	}
+
 	return &Router{
 		config: config,
 


### PR DESCRIPTION
Initialization with `nil logger` will cause **panic** on Router run 
https://github.com/vladtenlive/watermill/blob/3867ad50830e3b50d13685243c68c331cd42ff32/message/router.go#L355

<img width="1512" alt="image" src="https://github.com/ThreeDotsLabs/watermill/assets/56162873/73ef5095-bd0f-4c7f-8d92-b52193316045">
