### PR TITLE
Forwarder: propagate the enveloped message's Context

### DIFF
--- a/components/forwarder/envelope.go
+++ b/components/forwarder/envelope.go
@@ -69,6 +69,7 @@ func unwrapMessageFromEnvelope(msg *message.Message) (destinationTopic string, u
 
 	watermillMessage := message.NewMessage(envelopedMsg.UUID, envelopedMsg.Payload)
 	watermillMessage.Metadata = envelopedMsg.Metadata
+	watermillMessage.SetContext(envelopedMsg.Context())
 
 	return envelopedMsg.DestinationTopic, watermillMessage, nil
 }

--- a/components/forwarder/envelope.go
+++ b/components/forwarder/envelope.go
@@ -69,7 +69,7 @@ func unwrapMessageFromEnvelope(msg *message.Message) (destinationTopic string, u
 
 	watermillMessage := message.NewMessage(envelopedMsg.UUID, envelopedMsg.Payload)
 	watermillMessage.Metadata = envelopedMsg.Metadata
-	watermillMessage.SetContext(envelopedMsg.Context())
+	watermillMessage.SetContext(msg.Context())
 
 	return envelopedMsg.DestinationTopic, watermillMessage, nil
 }


### PR DESCRIPTION
This may be useful if the Forwarder's router middleware changes the Context in some way.