### PR TITLE
move problematic return statement out of for loop

### DIFF
--- a/components/cqrs/event_processor_group.go
+++ b/components/cqrs/event_processor_group.go
@@ -248,9 +248,9 @@ func (p EventGroupProcessor) routerHandlerGroupFunc(handlers []GroupEventHandler
 				logger.Debug("Error when handling event", watermill.LogFields{"err": err})
 				return err
 			}
-
-			return nil
 		}
+
+		return nil
 
 		if !p.config.AckOnUnknownEvent {
 			return fmt.Errorf("no handler found for event %s", p.config.Marshaler.NameFromMessage(msg))


### PR DESCRIPTION
The closure produced by `addEventHandlersToRoute` has a return statement inside the for loop which leads to a termination of the function in case of a successful event handling which is not the desired behavior if multiple handlers for the same event type are registered.