### PR TITLE
ci: update setup-go and checkout to latest action versions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,8 +11,8 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
       with:
         go-version: '^1.21.1'
     - run: make test_codecov

--- a/.github/workflows/pr-examples.yml
+++ b/.github/workflows/pr-examples.yml
@@ -8,8 +8,8 @@ jobs:
   validate-examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.21.1'
       - run: make validate_examples

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,16 +11,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.21.1'
       - run: make build
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.21.1'
       - name: golangci-lint
@@ -29,8 +29,8 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.21.1'
       - run: cat .env >> $GITHUB_ENV || true
@@ -46,8 +46,8 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.21.1'
       - run: make test_codecov


### PR DESCRIPTION
This should resolve node deprecation warnings when viewing action results in the github UI.