### PR TITLE
Clean up resources in Go channel pub sub

### DIFF
--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -205,7 +205,14 @@ func (g *GoChannel) Subscribe(ctx context.Context, topic string) (<-chan *messag
 		s.Close()
 
 		g.subscribersLock.Lock()
-		defer g.subscribersLock.Unlock()
+		defer func() {
+			// if there are no subscribers, clean up any resources related to the topic
+			if len(g.subscribers[topic]) == 0 {
+				delete(g.subscribers, topic)
+				g.subscribersByTopicLock.Delete(topic)
+			}
+			g.subscribersLock.Unlock()
+		}()
 
 		subLock, _ := g.subscribersByTopicLock.Load(topic)
 		subLock.(*sync.Mutex).Lock()

--- a/pubsub/gochannel/pubsub_internal_test.go
+++ b/pubsub/gochannel/pubsub_internal_test.go
@@ -1,0 +1,77 @@
+package gochannel
+
+import (
+	"context"
+	"log"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+func TestSubscribe_clean_subscriber_data(t *testing.T) {
+	subCount := 100
+	pubSub := NewGoChannel(
+		Config{OutputChannelBuffer: int64(subCount)},
+		watermill.NewStdLogger(false, false),
+	)
+	topicName := "test_topic"
+
+	allClosed := sync.WaitGroup{}
+
+	for i := 0; i < subCount; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		_, err := pubSub.Subscribe(ctx, topicName+"_index_"+strconv.Itoa(i))
+		require.NoError(t, err)
+
+		allClosed.Add(1)
+		go func() {
+			cancel()
+			allClosed.Done()
+		}()
+	}
+
+	log.Println("waiting for all closed")
+	allClosed.Wait()
+
+	assert.Len(t, pubSub.subscribers, 0)
+	lockCount := 0
+	pubSub.subscribersByTopicLock.Range(func(_, _ any) bool {
+		lockCount++
+		return true
+	})
+	assert.Equal(t, 0, lockCount)
+
+	assert.NoError(t, pubSub.Close())
+}
+
+func TestPublish_clean_lock_data(t *testing.T) {
+	messageCount := 100
+	pubSub := NewGoChannel(
+		Config{OutputChannelBuffer: int64(messageCount)},
+		watermill.NewStdLogger(false, false),
+	)
+	topicName := "test_topic"
+
+	_, err := pubSub.Subscribe(context.Background(), topicName+"_index_"+strconv.Itoa(0))
+	require.NoError(t, err)
+
+	for i := 0; i < messageCount; i++ {
+		err := pubSub.Publish(topicName+"_index_"+strconv.Itoa(i), message.NewMessage(watermill.NewShortUUID(), nil))
+		require.NoError(t, err)
+	}
+
+	lockCount := 0
+	pubSub.subscribersByTopicLock.Range(func(_, _ any) bool {
+		lockCount++
+		return true
+	})
+	assert.Equal(t, 1, lockCount)
+
+	assert.NoError(t, pubSub.Close())
+}


### PR DESCRIPTION
## Issue
Part of the issue reported here https://github.com/ThreeDotsLabs/watermill/issues/391
After testing, I've found same issue in `Publish` method. It uses `LoadOrStore` for fetching `subLock`. https://github.com/ThreeDotsLabs/watermill/blob/d20a6051456863fa147b9f9034b66500a6f0ffdf/pubsub/gochannel/pubsub.go#L96
That means if lock for specified topic doesn't exist it will create a new one. Because that data doesn't get removed, it means it will fill up map with new data even if there are no subscribers for this topic. If we use dynamic name of topics map size will continue to increase over time. 

With fix in https://github.com/ThreeDotsLabs/watermill/pull/396 data will only get removed if subscriber disconnects from specific topic. If no subscribers connect at any point, data will never get removed. 

## Fix
For `Publish` method, I've added condition to check if new lock has been loaded or added, and if it's added remove it at the end. 
There is an option to use `Load` instead of `LoadOrStore` and do early return here because if lock doesn't exist, it means there are no subscribers to send data to. I did't want to change much of the logic, but let me know if you think that is something that could be done. 
Only difference would be is that we would need to move handling of persistent message before that check. 

For Subscribe method, fix is introduced in https://github.com/ThreeDotsLabs/watermill/pull/396 which is included is this PR.

## Tests
Since these fixes are related to internal fields, I've added new test file with the same package name so we can test those fields.
First test asserts that all data from subscriber maps has been removed after subscribers disconnect.
Second tests asserts that no data is left over in subscribers lock map after publishing messages. Lock for single subscriber should still exist in map. 
