### PR TITLE
Add no subscribers fallback option to GoChannel Pub/Sub

### DIFF
--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -25,7 +25,7 @@ type Config struct {
 	// it will receive all previously produced messages.
 	//
 	// All messages are persisted to the memory (simple slice),
-	// so be aware that with large amount of messages you can go out of the memory.
+	// so be aware that with a large amount of messages you can run out of memory.
 	Persistent bool
 
 	// When true, Publish will block until subscriber Ack's the message.
@@ -66,10 +66,10 @@ type GoChannel struct {
 	persistedMessagesLock sync.RWMutex
 }
 
-// NewGoChannel creates new GoChannel Pub/Sub.
+// NewGoChannel creates a new GoChannel Pub/Sub.
 //
-// This GoChannel is not persistent.
-// That means if you send a message to a topic to which no subscriber is subscribed, that message will be discarded.
+// By default, GoChannel isn't persistent; that means messages sent to a topic
+// without any subscribers will be discarded if the fallback option isn't enabled.
 func NewGoChannel(config Config, logger watermill.LoggerAdapter) *GoChannel {
 	if logger == nil {
 		logger = watermill.NopLogger{}
@@ -97,7 +97,7 @@ func NewGoChannel(config Config, logger watermill.LoggerAdapter) *GoChannel {
 // Publish in GoChannel is NOT blocking until all consumers consume.
 // Messages will be sent in the background.
 //
-// Messages may be persisted or not, depending of persistent attribute.
+// Messages may be persisted or not, depending on whether the persistent option is enabled.
 func (g *GoChannel) Publish(topic string, messages ...*message.Message) error {
 	if g.isClosed() {
 		return errors.New("Pub/Sub closed")

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -77,7 +77,7 @@ func NewGoChannel(config Config, logger watermill.LoggerAdapter) *GoChannel {
 }
 
 // Publish in GoChannel is NOT blocking until all consumers consume.
-// Messages will be send in background.
+// Messages will be sent in the background.
 //
 // Messages may be persisted or not, depending of persistent attribute.
 func (g *GoChannel) Publish(topic string, messages ...*message.Message) error {

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 )
 
+// NoSubscribersFallbackTopic is the fallback topic messages without any subscribers will be sent to.
+// This is used if the `EnableFallback` configuration option is enabled.
+const NoSubscribersFallbackTopic = "*"
+
 // Config holds the GoChannel Pub/Sub's configuration options.
 type Config struct {
 	// Output channel buffer size.
@@ -26,6 +30,10 @@ type Config struct {
 	// When true, Publish will block until subscriber Ack's the message.
 	// If there are no subscribers, Publish will not block (also when Persistent is true).
 	BlockPublishUntilSubscriberAck bool
+
+	// When true, messages sent to a topic without any subscribers will be sent to the
+	// subscribers of the `*` topic.
+	EnableFallback bool
 }
 
 // GoChannel is the simplest Pub/Sub implementation.


### PR DESCRIPTION
I needed a way to listen to any message sent via the GoChannel Pub/Sub that didn't have a subscriber yet. This was mainly used for debugging but it could be useful for other purposes as well.

I made sure to add a test and left the rest of the tests untouched – the test suite is passing.

Would you be open to accepting this contribution? If so, I'd take another pass over the current implementation's comments, some would need updating (for example, `That means if you send a message to a topic to which no subscriber is subscribed, that message will be discarded.` – update: this is done ☑️).