### PR TITLE
Add deduplication middleware and publisher decorator

### DIFF
--- a/message/router/middleware/deduplicator.go
+++ b/message/router/middleware/deduplicator.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"hash/adler32"
 	"io"
@@ -45,7 +44,7 @@ func NewMessageHasherAdler32(readLimit int64) MessageHasher {
 		if err != nil && err != io.EOF {
 			return "", err
 		}
-		return hex.EncodeToString(h.Sum(nil)), nil
+		return string(h.Sum(nil)), nil
 	}
 }
 
@@ -68,7 +67,7 @@ func NewMessageHasherSHA256(readLimit int64) MessageHasher {
 		if err != nil && err != io.EOF {
 			return "", err
 		}
-		return hex.EncodeToString(h.Sum(nil)), nil
+		return string(h.Sum(nil)), nil
 	}
 }
 

--- a/message/router/middleware/deduplicator.go
+++ b/message/router/middleware/deduplicator.go
@@ -116,6 +116,15 @@ func (d *Deduplicator) cleanOut(tagsBefore time.Time) {
 	}
 }
 
+// Len returns the number of known tags that have not been
+// cleaned out yet.
+func (d *Deduplicator) Len() (count int) {
+	d.mu.Lock()
+	count = len(d.tags)
+	d.mu.Unlock()
+	return
+}
+
 // IsDuplicate returns true if the message hash tag calculated
 // using a [MessageHasher] was seen in deduplication time window.
 func (d *Deduplicator) IsDuplicate(m *message.Message) (bool, error) {

--- a/message/router/middleware/deduplicator.go
+++ b/message/router/middleware/deduplicator.go
@@ -1,0 +1,230 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash/adler32"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/pkg/errors"
+)
+
+// MessageHasherReadLimitMinimum specifies the least number
+// of bytes of a [message.Message] are used for calculating
+// their hash values using a [MessageHasher].
+const MessageHasherReadLimitMinimum = 64
+
+// MessageHasher returns a short tag that describes
+// a message. The tag should be unique per message,
+// but avoiding hash collisions entirely is not practical
+// for performance reasons. Used for powering [Deduplicator]s.
+type MessageHasher func(*message.Message) (string, error)
+
+// NewMessageHasherAdler32 generates message hashes using a fast
+// Adler-32 checksum of the [message.Message] body. Read
+// limit specifies how many bytes of the message are
+// used for calculating the hash.
+//
+// Lower limit improves performance but results in more false
+// positives. Read limit must be greater than
+// [MessageHasherReadLimitMinimum].
+func NewMessageHasherAdler32(readLimit int64) MessageHasher {
+	if readLimit < MessageHasherReadLimitMinimum {
+		readLimit = MessageHasherReadLimitMinimum
+	}
+
+	return func(m *message.Message) (string, error) {
+		h := adler32.New()
+		_, err := io.CopyN(h, bytes.NewReader(m.Payload), readLimit)
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		return hex.EncodeToString(h.Sum(nil)), nil
+	}
+}
+
+// NewMessageHasherSHA256 generates message hashes using a slower
+// but more resilient hashing of the [message.Message] body. Read
+// limit specifies how many bytes of the message are
+// used for calculating the hash.
+//
+// Lower limit improves performance but results in more false
+// positives. Read limit must be greater than
+// [MessageHasherReadLimitMinimum].
+func NewMessageHasherSHA256(readLimit int64) MessageHasher {
+	if readLimit < MessageHasherReadLimitMinimum {
+		readLimit = MessageHasherReadLimitMinimum
+	}
+
+	return func(m *message.Message) (string, error) {
+		h := sha256.New()
+		_, err := io.CopyN(h, bytes.NewReader(m.Payload), readLimit)
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		return hex.EncodeToString(h.Sum(nil)), nil
+	}
+}
+
+// NewMessageHasherFromMetadataField looks for a hash value
+// inside message metadata instead of calculating a new one.
+// Useful if a [MessageHasher] was applied in a previous
+// [message.HandlerFunc].
+func NewMessageHasherFromMetadataField(field string) MessageHasher {
+	return func(m *message.Message) (string, error) {
+		fromMetadata, ok := m.Metadata[field]
+		if ok {
+			return fromMetadata, nil
+		}
+		return "", fmt.Errorf("cannot recover hash value from metadata of message #%s: field %q is absent", m.UUID, field)
+	}
+}
+
+type Deduplicator struct {
+	tagger MessageHasher
+	window time.Duration
+
+	mu   *sync.Mutex
+	tags map[string]time.Time
+}
+
+func (d *Deduplicator) cleanOutLoop(ctx context.Context, ticker *time.Ticker) {
+	for {
+		select {
+		case <-ctx.Done():
+			return // execution ended, part the go routine
+		case tagsBefore := <-ticker.C:
+			d.cleanOut(tagsBefore)
+		}
+	}
+}
+
+func (d *Deduplicator) cleanOut(tagsBefore time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for hash, expires := range d.tags {
+		if expires.Before(tagsBefore) {
+			delete(d.tags, hash)
+		}
+	}
+}
+
+// IsDuplicate returns true if the message hash tag calculated
+// using a [MessageHasher] was seen in deduplication time window.
+func (d *Deduplicator) IsDuplicate(m *message.Message) (bool, error) {
+	tag, err := d.tagger(m)
+	if err != nil {
+		return false, err
+	}
+
+	t := time.Now()
+	d.mu.Lock()
+	_, alreadySeen := d.tags[tag]
+	if alreadySeen {
+		// NOTE: could also check if tag expires.After(t)
+		// and remove it for exact expiration
+		// instead of fuzzy until-next clean up expiration
+		// but this should not be needed for most use cases.
+		d.mu.Unlock()
+		return true, nil
+	}
+	d.tags[tag] = t.Add(d.window)
+	d.mu.Unlock()
+	return false, nil // first time, not a duplicate
+}
+
+// NewDeduplicator returns a new Deduplicator.
+// Call [Deduplicator.Middleware] for a new middleware
+// or [Deduplicator.Decorator] for a [message.PublisherDecorator].
+//
+// Use [NewMessageHasherAdler32] for fast tagging or
+// [NewMessageHasherSHA256] for minimal collisions.
+//
+// Window specifies the minimum duration of  how long the
+// duplicate tags are remembered for. Real duration can
+// extend up to 50% longer because it depends on the
+// clean up cycle.
+func NewDeduplicator(
+	tagger MessageHasher,
+	window time.Duration,
+) *Deduplicator {
+	if tagger == nil {
+		panic("cannot use a <nil> tagger")
+	}
+	if window < time.Millisecond {
+		panic("deduplication window of less than a millisecond is impractical")
+	}
+
+	d := &Deduplicator{
+		tagger: tagger,
+		window: window,
+
+		mu:   &sync.Mutex{},
+		tags: make(map[string]time.Time),
+	}
+	go d.cleanOutLoop(context.Background(), time.NewTicker(window/2))
+	return d
+}
+
+// Middleware returns the [Deduplicator] middleware.
+func (d *Deduplicator) Middleware(h message.HandlerFunc) message.HandlerFunc {
+	return func(msg *message.Message) ([]*message.Message, error) {
+		isDuplicate, err := d.IsDuplicate(msg)
+		if err != nil {
+			return nil, err
+		}
+		if isDuplicate {
+			return nil, nil
+		}
+		return h(msg)
+	}
+}
+
+type deduplicatingPublisherDecorator struct {
+	message.Publisher
+	deduplicator *Deduplicator
+}
+
+func (d *deduplicatingPublisherDecorator) Publish(
+	topic string,
+	messages ...*message.Message,
+) (err error) {
+	notRecent := make([]*message.Message, 0, len(messages))
+	isDuplicate := false
+
+	for _, m := range messages {
+		isDuplicate, err = d.deduplicator.IsDuplicate(m)
+		if err != nil {
+			return err
+		}
+		if isDuplicate {
+			m.Ack() // acknowledge and ignore
+			continue
+		}
+		notRecent = append(notRecent, m)
+	}
+	return d.Publisher.Publish(topic, notRecent...)
+}
+
+// PublisherDecorator returns a decorator that
+// acknowledges and drops every [message.Message] that
+// was recognized by a [Deduplicator].
+func (d *Deduplicator) PublisherDecorator() message.PublisherDecorator {
+	return func(pub message.Publisher) (message.Publisher, error) {
+		if pub == nil {
+			return nil, errors.New("cannot decorate a <nil> publisher")
+		}
+
+		return &deduplicatingPublisherDecorator{
+			Publisher:    pub,
+			deduplicator: d,
+		}, nil
+	}
+}

--- a/message/router/middleware/deduplicator.go
+++ b/message/router/middleware/deduplicator.go
@@ -132,7 +132,6 @@ func (d *Deduplicator) IsDuplicate(m *message.Message) (bool, error) {
 		return false, err
 	}
 
-	t := time.Now()
 	d.mu.Lock()
 	_, alreadySeen := d.tags[tag]
 	if alreadySeen {
@@ -143,7 +142,7 @@ func (d *Deduplicator) IsDuplicate(m *message.Message) (bool, error) {
 		d.mu.Unlock()
 		return true, nil
 	}
-	d.tags[tag] = t.Add(d.window)
+	d.tags[tag] = time.Now().Add(d.window)
 	d.mu.Unlock()
 	return false, nil // first time, not a duplicate
 }

--- a/message/router/middleware/deduplicator_test.go
+++ b/message/router/middleware/deduplicator_test.go
@@ -106,3 +106,45 @@ func TestDeduplicatorPublisherDecorator(t *testing.T) {
 	}
 	assert.Equal(t, 2, count)
 }
+
+func TestMessageHasherAdler32(t *testing.T) {
+	t.Parallel()
+
+	short := middleware.NewMessageHasherAdler32(0)
+	full := middleware.NewMessageHasherAdler32(middleware.MessageHasherReadLimitMinimum)
+
+	msg := message.NewMessage("adlerTest", []byte("some random data"))
+	h1, err := short(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := full(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h1 != h2 {
+		t.Fatal("MessageHasherReadLimitMinimum did not apply to Adler32 message hasher")
+	}
+}
+
+func TestMessageHasherSHA256(t *testing.T) {
+	t.Parallel()
+
+	short := middleware.NewMessageHasherSHA256(0)
+	full := middleware.NewMessageHasherSHA256(middleware.MessageHasherReadLimitMinimum)
+
+	msg := message.NewMessage("adlerTest", []byte("some random data"))
+	h1, err := short(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := full(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if h1 != h2 {
+		t.Fatal("MessageHasherReadLimitMinimum did not apply to SHA256 message hasher")
+	}
+}

--- a/message/router/middleware/deduplicator_test.go
+++ b/message/router/middleware/deduplicator_test.go
@@ -1,0 +1,108 @@
+package middleware_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeduplicatorMiddleware(t *testing.T) {
+	t.Parallel()
+
+	count := 0
+	h := middleware.NewDeduplicator(
+		middleware.NewMessageHasherAdler32(1024),
+		// middleware.NewMessageHasherSHA256(1024),
+		time.Second,
+	).Middleware(func(msg *message.Message) (messages []*message.Message, e error) {
+		count++
+		return nil, nil
+	})
+
+	for i := 0; i < 6; i++ { // only one should go through
+		msg := message.NewMessage(
+			fmt.Sprintf("first%d", i),
+			[]byte("1"),
+		)
+		_, err := h(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := 0; i < 2; i++ { // only one should go through
+		msg := message.NewMessage(
+			fmt.Sprintf("second%d", i),
+			[]byte("2"),
+		)
+		_, err := h(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	assert.Equal(t, 2, count)
+}
+
+func TestDeduplicatorPublisherDecorator(t *testing.T) {
+	t.Parallel()
+
+	pubSub := gochannel.NewGoChannel(gochannel.Config{
+		OutputChannelBuffer: 100,
+		Persistent:          true,
+	}, nil)
+	defer pubSub.Close()
+
+	const testDedupeTopic = "testTopic"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+	defer cancel()
+
+	decorated, err := middleware.NewDeduplicator(
+		// middleware.NewMessageHasherAdler32(1024),
+		middleware.NewMessageHasherSHA256(1024),
+		time.Second,
+	).PublisherDecorator()(pubSub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 6; i++ { // only one should go through
+		msg := message.NewMessage(
+			fmt.Sprintf("first%d", i),
+			[]byte("1"),
+		)
+		err := decorated.Publish(testDedupeTopic, msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := 0; i < 2; i++ { // only one should go through
+		msg := message.NewMessage(
+			fmt.Sprintf("second%d", i),
+			[]byte("2"),
+		)
+		err := decorated.Publish(testDedupeTopic, msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := pubSub.Subscribe(ctx, testDedupeTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for m := range got {
+		count++
+		m.Ack()
+		t.Log("got message:", m.UUID)
+	}
+	assert.Equal(t, 2, count)
+}


### PR DESCRIPTION
Useful for many projects. If similar messages appear, discards all but the first one in a given time window.