### PR TITLE
Change the autogenerated topic name to conform with Azure limits

### DIFF
--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -1214,7 +1214,7 @@ func assertConsumerGroupReceivedMessages(
 }
 
 func testTopicName(testID TestID) string {
-	return "topic_" + string(testID)
+	return "topic-" + string(testID)
 }
 
 func closePubSub(t *testing.T, pub message.Publisher, sub message.Subscriber) {


### PR DESCRIPTION
Azure does only allow letters, digits and dash `-` (if not first, nor last) in the names of Storage Queues.

Closes #424