### PR TITLE
docs: add watermill-rediszset to unofficial libraries

### DIFF
--- a/docs/content/docs/awesome.md
+++ b/docs/content/docs/awesome.md
@@ -30,6 +30,7 @@ If you know another library or are an author of one, please [add it to the list]
 * MongoDB https://github.com/cunyat/watermill-mongodb
 * MQTT https://github.com/perfect13/watermill-mqtt
 * NSQ https://github.com/chennqqi/watermill-nsq
+* Redis Zset https://github.com/stong1994/watermill-rediszset
 
 ### Logging
 


### PR DESCRIPTION
The watermill-rediszset implements a Pub/Sub interface that can be beneficial in certain scenarios, such as scheduled tasks.