### PR TITLE
Adds feature to use ULID in tests

### DIFF
--- a/pubsub/tests/bench_pubsub.go
+++ b/pubsub/tests/bench_pubsub.go
@@ -15,7 +15,7 @@ type BenchmarkPubSubConstructor func(n int) (message.Publisher, message.Subscrib
 // BenchSubscriber runs benchmark on a message Subscriber.
 func BenchSubscriber(b *testing.B, pubSubConstructor BenchmarkPubSubConstructor) {
 	pub, sub := pubSubConstructor(b.N)
-	topicName := testTopicName(NewTestID())
+	topicName := testTopicName(NewTestID(false))
 
 	messages, err := sub.Subscribe(context.Background(), topicName)
 	if err != nil {


### PR DESCRIPTION
Adds feature to use ULID instead of UUID in topic name and consumer group. 

Fixes #226's problem.