### PR TITLE
Use errors.Is for error comparison instead of direct equality checks

### DIFF
--- a/components/metrics/http.go
+++ b/components/metrics/http.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -31,7 +32,7 @@ func ServeHTTP(addr string, registry *prometheus.Registry) (cancel func()) {
 
 	go func() {
 		err := server.ListenAndServe()
-		if err != http.ErrServerClosed {
+		if !errors.Is(err, http.ErrServerClosed) {
 			panic(err)
 		}
 	}()

--- a/log.go
+++ b/log.go
@@ -1,6 +1,7 @@
 package watermill
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -216,7 +217,7 @@ func (c *CaptureLoggerAdapter) HasError(err error) bool {
 	defer c.lock.Unlock()
 
 	for _, capturedMsg := range c.captured[ErrorLogLevel] {
-		if capturedMsg.Err == err {
+		if errors.Is(err, capturedMsg.Err) {
 			return true
 		}
 	}

--- a/message/router/middleware/poison_test.go
+++ b/message/router/middleware/poison_test.go
@@ -2,21 +2,20 @@ package middleware_test
 
 import (
 	"context"
+	stdErrors "errors"
 	"testing"
 	"time"
 
-	"github.com/ThreeDotsLabs/watermill"
-	"github.com/ThreeDotsLabs/watermill/message/subscriber"
-	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
-
 	"github.com/hashicorp/go-multierror"
-
-	"github.com/ThreeDotsLabs/watermill/message"
-
-	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+	"github.com/ThreeDotsLabs/watermill/message/subscriber"
+	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
 )
 
 const topic = "testing_poison_queue_topic"
@@ -213,7 +212,7 @@ func TestPoisonQueueWithFilter_poison_queue(t *testing.T) {
 	msg := message.NewMessage("uuid", []byte("payload"))
 
 	poisonQueue, err := middleware.PoisonQueueWithFilter(&poisonPublisher, topic, func(err error) bool {
-		return err == poisonQueueErr
+		return stdErrors.Is(err, poisonQueueErr)
 	})
 	require.NoError(t, err)
 
@@ -232,7 +231,7 @@ func TestPoisonQueueWithFilter_non_poison_queue(t *testing.T) {
 	msg := message.NewMessage("uuid", []byte("payload"))
 
 	poisonQueue, err := middleware.PoisonQueueWithFilter(&poisonPublisher, topic, func(err error) bool {
-		return err != nonPoisonQueueErr
+		return !stdErrors.Is(err, nonPoisonQueueErr)
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR refactors error handling by replacing direct comparisons of errors (e.g., err == someError) with the use of errors.Is. 