### PR TITLE
Introducing Watermill Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/ThreeDotsLabs/watermill.svg)](https://pkg.go.dev/github.com/ThreeDotsLabs/watermill)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ThreeDotsLabs/watermill)](https://goreportcard.com/report/github.com/ThreeDotsLabs/watermill)
 [![codecov](https://codecov.io/gh/ThreeDotsLabs/watermill/branch/master/graph/badge.svg)](https://codecov.io/gh/ThreeDotsLabs/watermill)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Watermill%20Guru-006BFF)](https://gurubase.io/g/watermill)
 
 Watermill is a Go library for working efficiently with message streams. It is intended
 for building event driven applications, enabling event sourcing, RPC over messages,


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Watermill Guru](https://gurubase.io/g/watermill) to Gurubase. Watermill Guru uses the data from this repo and data from the [docs](https://watermill.io/docs/getting-started/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Watermill Guru", which highlights that Watermill now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Watermill Guru in Gurubase, just let me know that's totally fine.