### PR TITLE
Fix typos

### DIFF
--- a/_examples/basic/1-your-first-app/README.md
+++ b/_examples/basic/1-your-first-app/README.md
@@ -1,7 +1,7 @@
 # Your first Watermill app
 
 This example project shows a basic setup of Watermill. The application runs in a loop, consuming events from a Kafka
-topic, modyfing them and publishing to another topic.
+topic, modifying them and publishing to another topic.
 
 There's a docker-compose file included, so you can run the example and see it in action.
 

--- a/_examples/basic/2-realtime-feed/consumer/main.go
+++ b/_examples/basic/2-realtime-feed/consumer/main.go
@@ -162,7 +162,7 @@ func (p PostsCounter) Count(msg *message.Message) ([]*message.Message, error) {
 
 // postAdded might look similar to the postAdded type from producer.
 // It's intentionally not imported here. We avoid coupling the services at the cost of duplication.
-// We don't need all of it's data either (content is not displayed on the feed).
+// We don't need all of its data either (content is not displayed on the feed).
 type postAdded struct {
 	OccurredOn time.Time `json:"occurred_on"`
 	Author     string    `json:"author"`

--- a/_examples/basic/5-cqrs-protobuf/main.go
+++ b/_examples/basic/5-cqrs-protobuf/main.go
@@ -20,7 +20,7 @@ import (
 // BookRoomHandler is a command handler, which handles BookRoom command and emits RoomBooked.
 //
 // In CQRS, one command must be handled by only one handler.
-// When another handler with this command is added to command processor, error will be retuerned.
+// When another handler with this command is added to command processor, error will be returned.
 type BookRoomHandler struct {
 	eventBus *cqrs.EventBus
 }
@@ -65,7 +65,7 @@ func (b BookRoomHandler) Handle(ctx context.Context, c interface{}) error {
 	return nil
 }
 
-// OrderBeerOnRoomBooked is a event handler, which handles RoomBooked event and emits OrderBeer command.
+// OrderBeerOnRoomBooked is an event handler, which handles RoomBooked event and emits OrderBeer command.
 type OrderBeerOnRoomBooked struct {
 	commandBus *cqrs.CommandBus
 }
@@ -175,7 +175,7 @@ func main() {
 
 	// You can use any Pub/Sub implementation from here: https://watermill.io/pubsubs/
 	// Detailed RabbitMQ implementation: https://watermill.io/pubsubs/amqp/
-	// Commands will be send to queue, because they need to be consumed once.
+	// Commands will be sent to queue, because they need to be consumed once.
 	commandsAMQPConfig := amqp.NewDurableQueueConfig(amqpAddress)
 	commandsPublisher, err := amqp.NewPublisher(commandsAMQPConfig, logger)
 	if err != nil {

--- a/_examples/real-world-examples/delayed-messages/go.mod
+++ b/_examples/real-world-examples/delayed-messages/go.mod
@@ -1,4 +1,4 @@
-module delayed-messsages
+module delayed-messages
 
 go 1.23.0
 

--- a/_examples/real-world-examples/sending-webhooks/README.md
+++ b/_examples/real-world-examples/sending-webhooks/README.md
@@ -9,7 +9,7 @@ This example showcases the use of the **HTTP Publisher** to call webhooks with H
     1. `/foo_or_bar` for events of type `Foo` or `Bar`
     1. `/all` for all events.
 
-Additionally, services `zookeper` and `kafka` are present to provide backend for the Kafka producer and subscriber.
+Additionally, services `zookeeper` and `kafka` are present to provide backend for the Kafka producer and subscriber.
 
 ## Requirements
 

--- a/components/cqrs/event_processor.go
+++ b/components/cqrs/event_processor.go
@@ -22,7 +22,7 @@ type EventProcessorConfig struct {
 	SubscriberConstructor EventProcessorSubscriberConstructorFn
 
 	// OnHandle is called before handling event.
-	// OnHandle works in a similar way to middlewares: you can inject additional logic before and after handling a event.
+	// OnHandle works in a similar way to middlewares: you can inject additional logic before and after handling an event.
 	//
 	// Because of that, you need to explicitly call params.Handler.Handle() to handle the event.
 	//

--- a/components/cqrs/event_processor_group.go
+++ b/components/cqrs/event_processor_group.go
@@ -20,7 +20,7 @@ type EventGroupProcessorConfig struct {
 	SubscriberConstructor EventGroupProcessorSubscriberConstructorFn
 
 	// OnHandle is called before handling event.
-	// OnHandle works in a similar way to middlewares: you can inject additional logic before and after handling a event.
+	// OnHandle works in a similar way to middlewares: you can inject additional logic before and after handling an event.
 	//
 	// Because of that, you need to explicitly call params.Handler.Handle() to handle the event.
 	//

--- a/components/requestreply/backend_pubsub.go
+++ b/components/requestreply/backend_pubsub.go
@@ -94,7 +94,7 @@ type PubSubBackendConfig struct {
 	AckCommandErrors bool
 
 	// ReplyPublishErrorHandler if not nil will be invoked when sending the reply fails. If it returns an error
-	// the command will ba nacked.
+	// the command will be nacked.
 	ReplyPublishErrorHandler ReplyPublishErrorHandler
 }
 

--- a/components/requestreply/handler.go
+++ b/components/requestreply/handler.go
@@ -37,7 +37,7 @@ func NewCommandHandler[Command any](
 // NewCommandHandlerWithResult creates a new CommandHandler which supports the request-reply pattern with a result.
 // The result handler is handler compatible with cqrs.CommandHandler.
 //
-// In addition to cqrs.CommandHandler, it also allows returninga result from the handler.
+// In addition to cqrs.CommandHandler, it also allows returning a result from the handler.
 // The result is passed to the Backend implementation and sent to the caller.
 //
 // The logic if a command should be acked or not is based on the logic of the Backend.

--- a/components/requestreply/requestreply_test.go
+++ b/components/requestreply/requestreply_test.go
@@ -443,7 +443,7 @@ func TestRequestReply_without_result_multiple_replies(t *testing.T) {
 	}
 }
 
-func TestRequestReply_timout(t *testing.T) {
+func TestRequestReply_timeout(t *testing.T) {
 	timeout := time.Millisecond * 10
 
 	ts := NewTestServices[requestreply.NoResult](t, TestServicesConfig{

--- a/components/requeuer/requeuer.go
+++ b/components/requeuer/requeuer.go
@@ -40,11 +40,11 @@ type Config struct {
 	// Required.
 	GeneratePublishTopic func(params GeneratePublishTopicParams) (string, error)
 
-	// Delay is the duration to wait before requeueing the message. Optional.
+	// Delay is the duration to wait before requeuing the message. Optional.
 	// The default is no delay.
 	//
-	// This can be useful to avoid requeueing messages too quickly, for example, to avoid
-	// requeueing a message that failed to process due to a temporary issue.
+	// This can be useful to avoid requeuing messages too quickly, for example, to avoid
+	// requeuing a message that failed to process due to a temporary issue.
 	//
 	// Avoid setting this to a very high value, as it will block the message processing.
 	Delay time.Duration

--- a/docs/.prettierrc.yaml
+++ b/docs/.prettierrc.yaml
@@ -8,7 +8,7 @@ bracketSameLine: true
 quoteProps: consistent
 experimentalTernaries: true
 
-# Overrided config
+# Overridden config
 overrides:
   - files: ["*.md", "*.json", "*.yaml"]
     options:

--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -82,11 +82,11 @@ mainSections = ["docs"]
   # SCSS colors
   # backGround = "yellowgreen"
   ## Dark theme
-  # textDark = "#dee2e6" # "#dee2e6" (default), "#dee2e6" (orignal), or custom color
+  # textDark = "#dee2e6" # "#dee2e6" (default), "#dee2e6" (original), or custom color
   # accentDark = "#5d2f86" # "#5d2f86" (default), "#5d2f86" (original), or custom color
   ## Light theme
-  # textLight = "#1d2d35" # "#1d2d35" (default), "#1d2d35" (orignal), or custom color
-  # accentLight = "#8ed6fb" # "#8ed6fb" (default), "#8ed6fb" (orignal), or custom color
+  # textLight = "#1d2d35" # "#1d2d35" (default), "#1d2d35" (original), or custom color
+  # accentLight = "#8ed6fb" # "#8ed6fb" (default), "#8ed6fb" (original), or custom color
 
   # [doks.menu]
   #   [doks.menu.section]

--- a/docs/content/advanced/metrics.md
+++ b/docs/content/advanced/metrics.md
@@ -70,7 +70,7 @@ Enter the dashboard URL https://grafana.com/dashboards/9777 (or just the ID, 977
 
 ![Importing the dashboard](https://threedots.tech/watermill-io/grafana_import_dashboard.png)
 
-Then select your the Prometheus data source that scrapes the `/metrics` endpoint. Click on `Import`, and you're done!
+Then select your Prometheus data source that scrapes the `/metrics` endpoint. Click on `Import`, and you're done!
 
 ## Exported metrics
 

--- a/docs/content/docs/cqrs.md
+++ b/docs/content/docs/cqrs.md
@@ -111,13 +111,13 @@ For the beginning, we need to simulate the guest's action.
 
 `BookRoomHandler` will handle our command.
 
-{{% load-snippet-partial file="src-link/_examples/basic/5-cqrs-protobuf/main.go" first_line_contains="// BookRoomHandler is a command handler" last_line_contains="// OrderBeerOnRoomBooked is a event handler" padding_after="0" %}}
+{{% load-snippet-partial file="src-link/_examples/basic/5-cqrs-protobuf/main.go" first_line_contains="// BookRoomHandler is a command handler" last_line_contains="// OrderBeerOnRoomBooked is an event handler" padding_after="0" %}}
 
 ### Event handler
 
 As mentioned before, we want to order a beer every time when a room is booked (*"Whenever a Room is booked"* post-it). We do it by using the `OrderBeer` command.
 
-{{% load-snippet-partial file="src-link/_examples/basic/5-cqrs-protobuf/main.go" first_line_contains="// OrderBeerOnRoomBooked is a event handler" last_line_contains="// OrderBeerHandler is a command handler" padding_after="0" %}}
+{{% load-snippet-partial file="src-link/_examples/basic/5-cqrs-protobuf/main.go" first_line_contains="// OrderBeerOnRoomBooked is an event handler" last_line_contains="// OrderBeerHandler is a command handler" padding_after="0" %}}
 
 `OrderBeerHandler` is very similar to `BookRoomHandler`. The only difference is, that it sometimes returns an error when there are not enough beers, which causes redelivery of the command.
 You can find the entire implementation in the [example source code](https://github.com/ThreeDotsLabs/watermill/tree/master/_examples/basic/5-cqrs-protobuf/?utm_source=cqrs_doc).

--- a/docs/content/docs/messages-router.md
+++ b/docs/content/docs/messages-router.md
@@ -42,12 +42,12 @@ Not every handler will produce new messages. You can add this kind of handler by
 
 ## Ack
 
-By default, `msg.Ack()` is called when `HanderFunc` doesn't return an error. If an error is returned, `msg.Nack()` will be called.
+By default, `msg.Ack()` is called when `HandlerFunc` doesn't return an error. If an error is returned, `msg.Nack()` will be called.
 Because of this, you don't have to call `msg.Ack()` or `msg.Nack()` after a message is processed (you can if you want, of course).
 
 ## Producing messages
 
-When returning multiple messages from a handler, be aware that most Publisher implementations don't support [atomic publishing of messages]({{< ref "/docs/pub-sub#publishing-multiple-messages" >}}). It may end up producing only some of messages and sending `msg.Nack()` if the broker or the storage are not available.
+When returning multiple messages from a handler, be aware that most Publisher implementations don't support [atomic publishing of messages]({{< ref "/docs/pub-sub#publishing-multiple-messages" >}}). It may end up producing only some messages and sending `msg.Nack()` if the broker or the storage are not available.
 
 If it is an issue, consider publishing just one message with each handler.
 

--- a/docs/content/docs/middlewares.md
+++ b/docs/content/docs/middlewares.md
@@ -1,6 +1,6 @@
 +++
 title = "Middleware"
-description = "Add generic functionalities to your handlers in an inobtrusive way"
+description = "Add generic functionalities to your handlers in an unobtrusive way"
 date = 2019-06-01T19:00:00+01:00
 weight = -500
 draft = false 
@@ -20,7 +20,7 @@ Middleware wrap the handler function like this:
 ## Usage
 
 Middleware can be executed for all as well as for a specific handler in a router. When middleware is added directly 
-to a router it will be executed for all of handlers provided for a router. If a middleware should be executed only 
+to a router it will be executed for all handlers provided for a router. If a middleware should be executed only 
 for a specific handler, it needs to be added to handler in the router.
 
 Example usage is shown below:

--- a/docs/content/docs/pub-sub.md
+++ b/docs/content/docs/pub-sub.md
@@ -49,7 +49,7 @@ That means when some error occurs when processing a message and an Ack cannot be
 
 You need to keep it in mind and build your application to be [idempotent](http://www.cloudcomputingpatterns.org/idempotent_processor/) or implement a deduplication mechanism.
 
-Unfortunately, it's not possible to create an universal [*middleware*]({{< ref "/docs/messages-router#middleware" >}}) for deduplication, so we encourage you to build your own.
+Unfortunately, it's not possible to create a universal [*middleware*]({{< ref "/docs/messages-router#middleware" >}}) for deduplication, so we encourage you to build your own.
 
 ## Universal tests
 

--- a/docs/content/docs/snippets/tail-log-file/main.go
+++ b/docs/content/docs/snippets/tail-log-file/main.go
@@ -13,7 +13,7 @@ import (
 // this will `tail -f` a log file and publish an alert if a line fulfils some criterion
 
 func main() {
-	// if an alert is raised, the offending line will be publisher on this
+	// if an alert is raised, the offending line will be published on this
 	// this would be set to an actual publisher
 	var alertPublisher message.Publisher
 

--- a/message/router.go
+++ b/message/router.go
@@ -471,7 +471,7 @@ func (r *Router) RunHandlers(ctx context.Context) error {
 	return nil
 }
 
-// closeWhenAllHandlersStopped closed router, when all handlers has stopped,
+// closeWhenAllHandlersStopped closed router, when all handlers have stopped,
 // because for example all subscriptions are closed.
 func (r *Router) closeWhenAllHandlersStopped(ctx context.Context) {
 	r.handlersLock.RLock()
@@ -553,8 +553,8 @@ func (r *Router) Close() error {
 	close(r.closingInProgressCh)
 	defer close(r.closedCh)
 
-	timeouted := r.waitForHandlers()
-	if timeouted {
+	timedout := r.waitForHandlers()
+	if timedout {
 		return errors.New("router close timeout")
 	}
 

--- a/pubsub/gochannel/pubsub.go
+++ b/pubsub/gochannel/pubsub.go
@@ -77,9 +77,9 @@ func NewGoChannel(config Config, logger watermill.LoggerAdapter) *GoChannel {
 }
 
 // Publish in GoChannel is NOT blocking until all consumers consume.
-// Messages will be send in background.
+// Messages will be sent in background.
 //
-// Messages may be persisted or not, depending of persistent attribute.
+// Messages may be persisted or not, depending on persistent attribute.
 func (g *GoChannel) Publish(topic string, messages ...*message.Message) error {
 	if g.isClosed() {
 		return errors.New("Pub/Sub closed")

--- a/pubsub/sync/waitgroup.go
+++ b/pubsub/sync/waitgroup.go
@@ -6,7 +6,7 @@ import (
 )
 
 // WaitGroupTimeout adds timeout feature for sync.WaitGroup.Wait().
-// It returns true, when timeouted.
+// It returns true, when timed out.
 func WaitGroupTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	wgClosed := make(chan struct{}, 1)
 	go func() {

--- a/pubsub/sync/waitgroup_test.go
+++ b/pubsub/sync/waitgroup_test.go
@@ -11,14 +11,14 @@ import (
 func TestWaitGroupTimeout_no_timeout(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
-	timeouted := WaitGroupTimeout(wg, time.Millisecond*100)
-	assert.False(t, timeouted)
+	timedout := WaitGroupTimeout(wg, time.Millisecond*100)
+	assert.False(t, timedout)
 }
 
 func TestWaitGroupTimeout_timeout(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	timeouted := WaitGroupTimeout(wg, time.Millisecond*100)
-	assert.True(t, timeouted)
+	timedout := WaitGroupTimeout(wg, time.Millisecond*100)
+	assert.True(t, timedout)
 }

--- a/pubsub/tests/test_pubsub.go
+++ b/pubsub/tests/test_pubsub.go
@@ -106,7 +106,7 @@ type Features struct {
 	// Some Pub/Subs guarantee the order only when one subscriber is subscribed at a time.
 	GuaranteedOrderWithSingleSubscriber bool
 
-	// Persistent should be true, if messages are persistent between multiple instancees of a Pub/Sub
+	// Persistent should be true, if messages are persistent between multiple instances of a Pub/Sub
 	// (in practice, only GoChannel doesn't support that).
 	Persistent bool
 
@@ -555,7 +555,7 @@ func TestNoAck(
 	case <-receivedMessage:
 	// ok
 	case <-time.After(defaultTimeout):
-		t.Fatal("timeouted")
+		t.Fatal("timed out")
 	}
 
 	select {
@@ -647,7 +647,7 @@ func TestContinueAfterSubscribeClose(
 	}
 
 	// to make this test more robust - let's consume all missing messages
-	// (we care here if we didn't lost any message, not if we received duplicated)
+	// (we care here if we didn't lose any message, not if we received duplicated)
 	missingMessagesCount := totalMessagesCount - len(receivedMessages)
 	if missingMessagesCount > 0 && !tCtx.Features.ExactlyOnceDelivery {
 		messages, err := sub.Subscribe(context.Background(), topicName)

--- a/tools/mill/README.md
+++ b/tools/mill/README.md
@@ -91,7 +91,7 @@ Additional flags are available for `subscription add` to regulate the newly crea
 
 #### Listing subscriptions
 
-You can use `mill` to list existings subscriptions:
+You can use `mill` to list existing subscriptions:
 
 ```bash
 mill googlecloud subscription ls [-t topic]

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 )
 
-func testuUniqness(t *testing.T, genFunc func() string) {
+func testUniqueness(t *testing.T, genFunc func() string) {
 	producers := 100
 	uuidsPerProducer := 10000
 
@@ -45,13 +45,13 @@ func testuUniqness(t *testing.T, genFunc func() string) {
 }
 
 func TestUUID(t *testing.T) {
-	testuUniqness(t, watermill.NewUUID)
+	testUniqueness(t, watermill.NewUUID)
 }
 
 func TestShortUUID(t *testing.T) {
-	testuUniqness(t, watermill.NewShortUUID)
+	testUniqueness(t, watermill.NewShortUUID)
 }
 
 func TestULID(t *testing.T) {
-	testuUniqness(t, watermill.NewULID)
+	testUniqueness(t, watermill.NewULID)
 }


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully).

* timeouted (8)
* testu (4)
* uniqness (4)
* orignal (3)
* requeueing (3)
* ba (1)
* existings (1)
* hander (1)
* inobtrusive (1)
* instancees (1)
* messsages (1)
* modyfing (1)
* overrided (1)
* retuerned (1)
* returninga (1)
* timout (1)
* zookeper (1)