### PR TITLE
Router: publish messages in bulk

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -825,15 +825,13 @@ func (h *handler) publishProducedMessages(producedMessages Messages, msgFields w
 		"publish_topic":           h.publishTopic,
 	}))
 
-	for _, msg := range producedMessages {
-		if err := h.publisher.Publish(h.publishTopic, msg); err != nil {
-			// todo - how to deal with it better/transactional/retry?
-			h.logger.Error("Cannot publish message", err, msgFields.Add(watermill.LogFields{
-				"not_sent_message": fmt.Sprintf("%#v", producedMessages),
-			}))
+	if err := h.publisher.Publish(h.publishTopic, producedMessages...); err != nil {
+		// todo - how to deal with it better/transactional/retry?
+		h.logger.Error("Cannot publish messages", err, msgFields.Add(watermill.LogFields{
+			"not_sent_message": fmt.Sprintf("%#v", producedMessages),
+		}))
 
-			return err
-		}
+		return err
 	}
 
 	return nil

--- a/message/router.go
+++ b/message/router.go
@@ -826,7 +826,6 @@ func (h *handler) publishProducedMessages(producedMessages Messages, msgFields w
 	}))
 
 	if err := h.publisher.Publish(h.publishTopic, producedMessages...); err != nil {
-		// todo - how to deal with it better/transactional/retry?
 		h.logger.Error("Cannot publish messages", err, msgFields.Add(watermill.LogFields{
 			"not_sent_message": fmt.Sprintf("%#v", producedMessages),
 		}))


### PR DESCRIPTION
Currently, the router will publish produced messaged by calling `Publish` individually, even though the bulk API exists.

This change works the same, although it can be handy for some custom implementations when you want to treat the produced messages as a group. For some implementations, it could also slightly improve publish performance.