### PR TITLE
fix: first added middleware should be executed first

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -622,7 +622,7 @@ func (h *handler) run(ctx context.Context, middlewares []middleware) {
 
 	middlewareHandler := h.handlerFunc
 	// first added middlewares should be executed first (so should be at the top of call stack)
-	for i := len(middlewares) - 1; i >= 0; i-- {
+	for i := 0; i < len(middlewares); i++ {
 		currentMiddleware := middlewares[i]
 		isValidHandlerLevelMiddleware := currentMiddleware.HandlerName == h.name
 		if currentMiddleware.IsRouterLevel || isValidHandlerLevelMiddleware {


### PR DESCRIPTION
Reverse the middleware execution order.
router.go:210 and router.go:197 use to append middleware instead of prepend it.

Reversing the loop so it will execute the middleware that got added first.