### PR TITLE
Restore message context in Timeout middleware

### DIFF
--- a/message/router/middleware/timeout.go
+++ b/message/router/middleware/timeout.go
@@ -9,11 +9,16 @@ import (
 
 // Timeout makes the handler cancel the incoming message's context after a specified time.
 // Any timeout-sensitive functionality of the handler should listen on msg.Context().Done() to know when to fail.
+// Before exiting this middleware, message's original context is restored to not disrupt the logic of possible
+// enveloping handlers (e.g. Retry) that also rely on message context.
 func Timeout(timeout time.Duration) func(message.HandlerFunc) message.HandlerFunc {
 	return func(h message.HandlerFunc) message.HandlerFunc {
 		return func(msg *message.Message) ([]*message.Message, error) {
+			orgCtx := msg.Context()
+
 			ctx, cancel := context.WithTimeout(msg.Context(), timeout)
 			defer func() {
+				msg.SetContext(orgCtx)
 				cancel()
 			}()
 

--- a/message/router/middleware/timeout_test.go
+++ b/message/router/middleware/timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -25,6 +26,9 @@ func TestTimeout(t *testing.T) {
 		}
 	})
 
-	_, err := h(message.NewMessage("any-uuid", nil))
+	msg := message.NewMessage("any-uuid", nil)
+
+	_, err := h(msg)
 	require.NoError(t, err)
+	assert.Nil(t, msg.Context().Err())
 }


### PR DESCRIPTION
This resolves #467.

It simply stores the original message context and restores it in the `defer`.