### PR TITLE
- Added EventName(to event_processor) and CommandName(to command_proc…

### DIFF
--- a/components/cqrs/command_processor.go
+++ b/components/cqrs/command_processor.go
@@ -95,6 +95,7 @@ type CommandProcessorGenerateSubscribeTopicParams struct {
 type CommandProcessorSubscriberConstructorFn func(CommandProcessorSubscriberConstructorParams) (message.Subscriber, error)
 
 type CommandProcessorSubscriberConstructorParams struct {
+	CommandName string
 	HandlerName string
 	Handler     CommandHandler
 }
@@ -290,6 +291,7 @@ func (p CommandProcessor) addHandlerToRouter(r *message.Router, handler CommandH
 	logger.Debug("Adding CQRS command handler to router", nil)
 
 	subscriber, err := p.config.SubscriberConstructor(CommandProcessorSubscriberConstructorParams{
+		CommandName: commandName,
 		HandlerName: handlerName,
 		Handler:     handler,
 	})

--- a/components/cqrs/event_processor.go
+++ b/components/cqrs/event_processor.go
@@ -91,6 +91,7 @@ type EventProcessorGenerateSubscribeTopicParams struct {
 type EventProcessorSubscriberConstructorFn func(EventProcessorSubscriberConstructorParams) (message.Subscriber, error)
 
 type EventProcessorSubscriberConstructorParams struct {
+	EventName    string
 	HandlerName  string
 	EventHandler EventHandler
 }
@@ -279,6 +280,7 @@ func (p EventProcessor) addHandlerToRouter(r *message.Router, handler EventHandl
 	}
 
 	subscriber, err := p.config.SubscriberConstructor(EventProcessorSubscriberConstructorParams{
+		EventName:    eventName,
 		HandlerName:  handlerName,
 		EventHandler: handler,
 	})


### PR DESCRIPTION
…essor)

<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background
I am trying to use cqrs with the new nats jetstream api and running into an issue with creating consumers correctly due to the params not including EventName. 
In Nats Jetstream - for a stream you can define a Name and Subject - like this:
```
    cfg := jetstream.StreamConfig{
        Name:     "EVENTS",
        Subjects: []string{"events.>"},
    }
 ```
so I can use EventBus to publish with publishtopic: "events.<EventName>".

For jetstream consumers - consumer can only connect to a stream with a name(so "EVENTS" for this example) and need to setup a subject-filter to filter the messages the consumer receives - so EventName is required to setup a filter for "events.<EventName>" on the consumer and  EventProcessorSubscriberConstructorParams only has HandlerName.
<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address? N/A
- What new functionality does it add? Adds the EventName/CommandName to EventProcessorSubscriberConstructorParams/CommandProcessorSubscriberConstructorParams
- Why are these changes needed? The changes are required inorder to be able to setup subject-filters on Nats Jetstream consumer.
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->

### Detail
Minor update - adds EventName/CommandName to EventProcessorSubscriberConstructorParams/CommandProcessorSubscriberConstructorParams 

### Alternative approaches considered (if applicable)

<!-- If applicable, describe alternative approaches you considered and why you chose this one. -->

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [x] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [x] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).