### PR TITLE
Add handler_name to logs of handler.handleMessage()

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -786,7 +786,7 @@ func (h *handler) handleClose(ctx context.Context) {
 
 func (h *handler) handleMessage(msg *Message, handler HandlerFunc) {
 	defer h.runningHandlersWg.Done()
-	msgFields := watermill.LogFields{"message_uuid": msg.UUID}
+	msgFields := watermill.LogFields{"message_uuid": msg.UUID, "handler_name": h.name}
 
 	defer func() {
 		if recovered := recover(); recovered != nil {


### PR DESCRIPTION
### Motivation / Background

See this issue: TODO

### Detail

See this issue: TODO

### Checklist

Next to the checklist, an additional check I've done: the naming of this field matches other places where we log this. For example:

**components/cqrs/command_handler.go**
``` go
func (p EventProcessor) addHandlerToRouter(r *message.Router, handler EventHandler) (*message.Handler, error) {
	// [...] 
	
	handlerName := handler.HandlerName()
	
	// [...]

	logger := p.config.Logger.With(watermill.LogFields{
		"event_handler_name": handlerName,
		"topic":              topicName,
	})

	// [...]

	return addHandlerToRouter(p.config.Logger, r, handlerName, topicName, handlerFunc, subscriber), nil
}
```

**components/cqrs/command_processor.go**

```go
func (p CommandProcessor) addHandlerToRouter(r *message.Router, handler CommandHandler) (*message.Handler, error) {
	handlerName := handler.HandlerName()
	// [...]

	logger := p.config.Logger.With(watermill.LogFields{
		"command_handler_name": handlerName,
		"topic":                topicName,
	})

	// [...]

	return r.AddNoPublisherHandler(
		handlerName,
		topicName,
		subscriber,
		handlerFunc,
	), nil
}

```

