### PR TITLE
Add NewMessageWithContext()

### DIFF
--- a/docs/content/docs/message.md
+++ b/docs/content/docs/message.md
@@ -34,4 +34,10 @@ When a message is processed, you should send an [`Ack()`]({{< ref "#ack" >}}) or
 
 Message contains the standard library context, just like an HTTP request.
 
+This context is used to propagate cancellation and deadlines when publishing and processing messages.
+
+You can set the context using the `SetContext` method or the `NewMessageWithContext` constructor.
+
+{{% load-snippet-partial file="src-link/message/message.go" first_line_contains="// NewMessageWithContext" last_line_contains="}" %}}
+
 {{% load-snippet-partial file="src-link/message/message.go" first_line_contains="// Context" last_line_contains="func (m *Message) SetContext" padding_after="2" %}}

--- a/message/message.go
+++ b/message/message.go
@@ -62,6 +62,13 @@ func NewMessage(uuid string, payload Payload) *Message {
 	}
 }
 
+// NewMessageWithContext creates a new Message with given uuid, payload, and context.
+func NewMessageWithContext(ctx context.Context, uuid string, payload Payload) *Message {
+	msg := NewMessage(uuid, payload)
+	msg.SetContext(ctx)
+	return msg
+}
+
 type ackType int
 
 const (


### PR DESCRIPTION
This is the equivalent of calling `NewMessage()` and `SetContext()` separately, but should give a hint that when publishing messages, the message's context is used.
