### PR TITLE
docs: Fix spelling error: 'ques' to 'queues' in SNS configuration aws.md

### DIFF
--- a/docs/content/pubsubs/aws.md
+++ b/docs/content/pubsubs/aws.md
@@ -196,7 +196,7 @@ Additionally, if `sns.SubscriberConfig.DoNotSetQueueAccessPolicy` is not enabled
 
 {{% load-snippet-partial file="src-link/watermill-aws/sns/config.go" first_line_contains="type SubscriberConfig struct " last_line_contains="type GenerateSqsQueueNameFn" %}}
 
-Additionally, because SNS Subscriber uses SQS ques as "subscriptions", you need to pass [SQS configuration](#sqs-configuration) as well.
+Additionally, because SNS Subscriber uses SQS queues as "subscriptions", you need to pass [SQS configuration](#sqs-configuration) as well.
 
 ### Resolving Queue URL
 


### PR DESCRIPTION


<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

Fix spelling error: 'ques' to 'queues' in SNS configuration documentatio

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->

### Detail


### Alternative approaches considered (if applicable)

<!-- If applicable, describe alternative approaches you considered and why you chose this one. -->

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [ ] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [ ] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).