### PR TITLE
docs: add suport of mysql delayed messages

### DIFF
--- a/docs/content/advanced/delayed-messages.md
+++ b/docs/content/advanced/delayed-messages.md
@@ -37,6 +37,7 @@ You can also use `delay.Until` instead of `delay.For` to specify `time.Time` ins
 ## Supported Pub/Subs
 
 * [PostgreSQL](/pubsubs/sql/)
+* [MySQL](/pubsubs/sql/)
 
 ## Full Example
 

--- a/docs/content/advanced/requeuing-after-error.md
+++ b/docs/content/advanced/requeuing-after-error.md
@@ -50,6 +50,6 @@ A better way to use the `Requeuer` is to combine it with the `Poison` middleware
 The middleware moves messages to a separate "poison" topic.
 Then, the requeuer moves them back to the original topic based on the metadata.
 
-You combine this with a Pub/Sub that supports delayed messages.
+You combine this with a Pub/Sub that [supports delayed messages](/advanced/delayed-messages/#supported-pubsubs).
 See the [full example based on PostgreSQL](https://github.com/ThreeDotsLabs/watermill/blob/master/_examples/real-world-examples/delayed-requeue/main.go).
 

--- a/docs/content/pubsubs/sql.md
+++ b/docs/content/pubsubs/sql.md
@@ -117,7 +117,8 @@ You can use it to filter messages by some condition in the payload or in the met
 Additionally, you can choose to delete messages from the table after they are acknowledged.
 Thanks to this, the table doesn't grow in size with time.
 
-Currently, this schema is supported only for PostgreSQL.
+This schema is supported by both PostgreSQL and MySQL.
+The example below is based on PostgreSQL, but the same approach can be used with MySQL. 
 
 {{% load-snippet-partial file="src-link/watermill-sql/pkg/sql/queue_schema_adapter_postgresql.go" first_line_contains="// PostgreSQLQueueSchema" last_line_contains="}" %}}
 


### PR DESCRIPTION
### Motivation / Background
Documenation updated related to PRs:

https://github.com/ThreeDotsLabs/watermill-sql/pull/52
https://github.com/ThreeDotsLabs/watermill-sql/pull/51

### Detail

Documentation update about added support of MySQL delayed messages.

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [ ] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [ ] Code has no breaking changes.
- [x] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).