### PR TITLE
Remove archived logur project from awesome.md

### DIFF
--- a/docs/content/docs/awesome.md
+++ b/docs/content/docs/awesome.md
@@ -40,7 +40,6 @@ check out [Implementing custom Pub/Sub](/development/pub-sub-implementing).
 * logrus
   * https://github.com/ma-hartma/watermill-logrus-adapter
   * https://github.com/UNIwise/walrus
-* logur https://github.com/logur/integration-watermill
 * zap
   * https://github.com/garsue/watermillzap
   * https://github.com/pperaltaisern/watermillzap


### PR DESCRIPTION
The logur project linked under the Logging section is archived  and no longer maintained.
The repository recommends using log/slog instead.

This PR removes the outdated link to avoid confusion for new users.

