### PR TITLE
Add defer statement to close database connection

### DIFF
--- a/_examples/real-world-examples/exactly-once-delivery-counter/worker/main.go
+++ b/_examples/real-world-examples/exactly-once-delivery-counter/worker/main.go
@@ -20,6 +20,8 @@ const topic = "counter"
 
 func main() {
 	db := createDB()
+	defer db.Close()
+
 	logger := watermill.NewStdLogger(false, false)
 
 	go runWatermillRouter(db, logger)


### PR DESCRIPTION
Some of the SQL‑based examples open a database connection but never close it.
While the examples run indefinitely, adding defer db.Close() is considered best practice

