### PR TITLE
Add defer statement to close database connection

### DIFF
--- a/_examples/real-world-examples/exactly-once-delivery-counter/server/main.go
+++ b/_examples/real-world-examples/exactly-once-delivery-counter/server/main.go
@@ -18,6 +18,8 @@ const topic = "counter"
 
 func main() {
 	db := createDB()
+	defer db.Close()
+
 	logger := watermill.NewStdLogger(false, false)
 
 	r := chi.NewRouter()


### PR DESCRIPTION
Some of the SQL‑based examples open a database connection but never close it.
While the examples run indefinitely, adding defer db.Close() is considered best practice
