### PR TITLE
Router closes ppublisher before processing is done

### DIFF
--- a/message/router.go
+++ b/message/router.go
@@ -643,10 +643,12 @@ type handler struct {
 }
 
 func (h *handler) run(ctx context.Context, middlewares []middleware) {
-	h.logger.Info("Starting handler", watermill.LogFields{
+	lf := watermill.LogFields{
 		"subscriber_name": h.name,
 		"topic":           h.subscribeTopic,
-	})
+	}
+
+	h.logger.Info("Starting handler", lf)
 
 	middlewareHandler := h.handlerFunc
 	// first added middlewares should be executed first (so should be at the top of call stack)
@@ -669,9 +671,9 @@ func (h *handler) run(ctx context.Context, middlewares []middleware) {
 	}
 
 	if h.publisher != nil {
-		h.logger.Debug("Waiting on message processing go routines", nil)
+		h.logger.Debug("Waiting on message processing go routines", lf)
 		h.runningHandlersWg.Wait()
-		h.logger.Debug("Done Waiting on message processing go routines", nil)
+		h.logger.Debug("Done Waiting on message processing go routines", lf)
 
 		h.logger.Debug("Waiting for publisher to close", nil)
 		if err := h.publisher.Close(); err != nil {

--- a/message/router.go
+++ b/message/router.go
@@ -669,6 +669,10 @@ func (h *handler) run(ctx context.Context, middlewares []middleware) {
 	}
 
 	if h.publisher != nil {
+		h.logger.Debug("Waiting on message processing go routines", nil)
+		h.runningHandlersWg.Wait()
+		h.logger.Debug("Done Waiting on message processing go routines", nil)
+
 		h.logger.Debug("Waiting for publisher to close", nil)
 		if err := h.publisher.Close(); err != nil {
 			h.logger.Error("Failed to close publisher", err, nil)


### PR DESCRIPTION
### Motivation / Background

This PR addresses a race condition during shutdown where the publisher could be closed while handlers were still processing messages. This often resulted in "publisher closed" errors or lost messages during the final seconds of a service's lifecycle.

Changes:
* Added a synchronisation to wait for handlers to complete their work

Note (!):
* You still need to handle `msg.Context()` manually during app stopping. It is `Done()` immediately, and any resources (like DB, cache, etc.) will cancel processing immediately as well.

Fixes #446

### Checklist

- [ ] I wrote tests for the changes.
- [*] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [*] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).