### PR TITLE
fix(example): close HTTP response body and add retry backoff

### DIFF
--- a/_examples/real-world-examples/exactly-once-delivery-counter/run.go
+++ b/_examples/real-world-examples/exactly-once-delivery-counter/run.go
@@ -139,12 +139,18 @@ func sendCountRequest(counterUUID string) {
 	for {
 		resp, err := http.Post("http://localhost:8080/count/"+counterUUID, "", nil)
 		if err != nil {
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 
-		if resp.StatusCode == http.StatusNoContent {
+		status := resp.StatusCode
+		resp.Body.Close()
+
+		if status == http.StatusNoContent {
 			break
 		}
+
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Fixes #664

## Problem

`sendCountRequest` in the exactly-once-delivery-counter example:

1. **Never closes `resp.Body`** — leaks file descriptors and TCP connections under load
2. **No retry backoff** — retries immediately in a tight loop on error or non-204 status

## Fix

- Close `resp.Body` after reading the status code
- Add 100ms sleep between retries