### PR TITLE
exactly-once-counter: drain and close HTTP body, back off on retryable failures

### DIFF
--- a/_examples/real-world-examples/exactly-once-delivery-counter/run.go
+++ b/_examples/real-world-examples/exactly-once-delivery-counter/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	stdSQL "database/sql"
 	"fmt"
+	"io"
 	"net/http"
 	"os/exec"
 	"sync"
@@ -139,12 +140,26 @@ func sendCountRequest(counterUUID string) {
 	for {
 		resp, err := http.Post("http://localhost:8080/count/"+counterUUID, "", nil)
 		if err != nil {
+			// No resp to close on transport errors; back off briefly so we
+			// do not hammer the handler in a tight retry loop.
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 
-		if resp.StatusCode == http.StatusNoContent {
+		status := resp.StatusCode
+		// Drain and close the body on every attempt. http.Post returns a
+		// non-nil resp.Body even for non-2xx responses, and skipping the
+		// drain pins the underlying TCP connection until GC (#664).
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if status == http.StatusNoContent {
 			break
 		}
+
+		// Any non-2xx response: back off instead of retrying in a tight
+		// loop, same rationale as the transport-error branch above.
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Fixes #664.

`sendCountRequest` hits `http.Post` in a tight loop and never closes the response body, pinning the underlying TCP connection to the example counter until the garbage collector eventually runs. On error or non-204 responses the loop retries immediately, so the unread bodies pile up faster than GC reclaims them and the example run stalls on FD / connection pressure as soon as the server momentarily returns 4xx/5xx.

This drains and closes the body on every iteration, and sleeps 100ms before retrying both the transport-error path and the non-204 path so we do not hammer the counter handler in a spin loop when the backend is briefly unhealthy. Behaviour on the happy path (204) is unchanged.