### PR TITLE
_examples/exactly-once-counter: close HTTP response body and back off retries

### DIFF
--- a/_examples/real-world-examples/exactly-once-delivery-counter/run.go
+++ b/_examples/real-world-examples/exactly-once-delivery-counter/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	stdSQL "database/sql"
 	"fmt"
+	"io"
 	"net/http"
 	"os/exec"
 	"sync"
@@ -139,12 +140,20 @@ func sendCountRequest(counterUUID string) {
 	for {
 		resp, err := http.Post("http://localhost:8080/count/"+counterUUID, "", nil)
 		if err != nil {
+			// Back off a bit so transient errors do not spin the CPU.
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
+
+		// Drain and close the body so net/http can reuse the connection
+		// and goroutines / file descriptors are released (#664).
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNoContent {
 			break
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary

`sendCountRequest` looped `http.Post` against `localhost:8080` without ever closing `resp.Body`. Every request leaked a TCP connection and its background reader goroutine; under the example's 5000-message load that accumulated into fd exhaustion / goroutine deadlock. A non-204 status also retried in a tight hot loop.

## Fix

- Drain + Close `resp.Body` after every response so `net/http` can reuse the connection.
- Sleep 100ms between retries (both on error and on non-204) to stop the CPU-spin.

Pure example-code change; no effect on the watermill library itself.

## Fixes

Fixes #664

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
