### PR TITLE
fix: retry middleware corrupts exponential backoff state

### DIFF
--- a/message/router/middleware/retry.go
+++ b/message/router/middleware/retry.go
@@ -125,10 +125,22 @@ func (r Retry) Middleware(h message.HandlerFunc) message.HandlerFunc {
 					return producedMessages, nil
 				}
 
+				// Compute the expected delay without calling NextBackOff().
+				// Calling expBackoff.NextBackOff() inside this function would
+				// advance the backoff's internal state, making backoff.Retry's
+				// own NextBackOff() call read a future interval.
+				// See https://github.com/ThreeDotsLabs/watermill/issues/XXX
+			approxDelay := computeBackoffDelay_atRetryNum(
+				retryNum,
+				expBackoff.InitialInterval,
+				expBackoff.MaxInterval,
+				expBackoff.Multiplier,
+			)
+
 				if r.ShouldRetry != nil && !r.ShouldRetry(RetryParams{
 					RetryNum: retryNum,
 					Err:      err,
-					Delay:    expBackoff.NextBackOff(),
+					Delay:    approxDelay,
 				}) {
 					// backoff.Permanent will stop the retry attempts
 					stoppedByPermanent = true
@@ -137,7 +149,7 @@ func (r Retry) Middleware(h message.HandlerFunc) message.HandlerFunc {
 
 				if r.OnRetryHook != nil && retryNum > 0 {
 					// call RetryHook function on each retry attempt.
-					r.OnRetryHook(retryNum, expBackoff.NextBackOff())
+					r.OnRetryHook(retryNum, approxDelay)
 				}
 				retryNum++
 				return producedMessages, err
@@ -169,4 +181,24 @@ func (r Retry) Middleware(h message.HandlerFunc) message.HandlerFunc {
 
 		return producedMessages, nil
 	}
+}
+
+// computeBackoffDelay_atRetryNum computes the expected backoff delay for the
+// given retry attempt number (1-based: retry 1 is the first retry, delay =
+// InitialInterval × Multiplier^(retry-1)), capped to MaxInterval. This does
+// NOT mutate any state, making it safe to use without corrupting the backoff
+// state machine maintained by backoff.Retry.
+func computeBackoffDelay_atRetryNum(retryNum int, initialInterval, maxInterval time.Duration, multiplier float64) time.Duration {
+	if retryNum <= 1 {
+		return initialInterval
+	}
+	delay := initialInterval
+	for i := 1; i < retryNum; i++ {
+		delay = time.Duration(float64(delay) * multiplier)
+		if maxInterval > 0 && delay > maxInterval {
+			delay = maxInterval
+			break
+		}
+	}
+	return delay
 }


### PR DESCRIPTION
## Bug

The Retry middleware in `message/router/middleware/retry.go` corrupts the exponential backoff state machine by calling `expBackoff.NextBackOff()` inside the `operation` function.

### Root Cause

The `operation` function passed to `backoff.Retry()` was calling `expBackoff.NextBackOff()` for two purposes:
1. To get the delay value for the `ShouldRetry` callback
2. To get the delay value for the `OnRetryHook` callback

Each call to `NextBackOff()`**advances** the backoff's internal state. When `backoff.Retry()` itself then calls `NextBackOff()` to determine the actual sleep duration, it receives a **future** interval.

### Impact

Retry delays were **double** what they should be. With `InitialInterval=10ms`, `Multiplier=2.0`:
- Expected: 10ms, 20ms, 40ms, 80ms
- Actual (buggy): 20ms, 40ms, 80ms, 160ms

### Fix

Replaced `NextBackOff()` calls with a new pure function `computeBackoffDelay_atRetryNum()` that computes the approximate delay from the config parameters without mutating any state. This lets `backoff.Retry()` continue to drive actual sleep durations correctly.

## Test Results

All existing tests pass (`go test ./...` — all green).

Fixes #224 (partial)